### PR TITLE
Group sync transformations in same event loop run

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -137,7 +137,7 @@
     new-parens: 2,
     newline-after-var: 0,
     no-array-constructor: 2,
-    no-continue: 2,
+    no-continue: 0,
     no-inline-comments: 0,
     no-lonely-if: 2,
     no-mixed-spaces-and-tabs: 2,

--- a/asynciterator.js
+++ b/asynciterator.js
@@ -1087,6 +1087,7 @@ SimpleTransformIterator.prototype._offset = 0;
 SimpleTransformIterator.prototype._limit = Infinity;
 SimpleTransformIterator.prototype._filter = function ()  { return true; };
 SimpleTransformIterator.prototype._map = null;
+SimpleTransformIterator.prototype._transform = null;
 
 /* Tries to read and transform an item */
 SimpleTransformIterator.prototype._read = function (count, done) {
@@ -1117,15 +1118,22 @@ function readAndTransformSimple(self, next, done) {
       continue;
     // One more valid item is read, deduct it from the limit
     self._limit--;
-    // Map and transform the item
+    // Map the item
     var mappedItem = self._map === null ? item : self._map(item);
-    if (mappedItem !== null) {
+    // Skip transformation if none specified
+    if (self._transform === null) {
+      if (mappedItem !== null)
+        self._push(mappedItem);
+      next();
+    }
+    // Transform a non-null item
+    else if (mappedItem !== null) {
       if (!self._optional)
         self._transform(mappedItem, next);
       else
         optionalTransform(self, mappedItem, next);
     }
-    // Don't transform a `null` item
+    // Skip null items; push the original item if the mapping was optional
     else {
       if (self._optional)
         self._push(item);

--- a/asynciterator.js
+++ b/asynciterator.js
@@ -1086,7 +1086,7 @@ TransformIterator.subclass(SimpleTransformIterator);
 SimpleTransformIterator.prototype._offset = 0;
 SimpleTransformIterator.prototype._limit = Infinity;
 SimpleTransformIterator.prototype._filter = function ()  { return true; };
-SimpleTransformIterator.prototype._map = function (item) { return item; };
+SimpleTransformIterator.prototype._map = null;
 
 /* Tries to read and transform an item */
 SimpleTransformIterator.prototype._read = function (count, done) {
@@ -1118,7 +1118,7 @@ function readAndTransformSimple(self, next, done) {
     // One more valid item is read, deduct it from the limit
     self._limit--;
     // Map and transform the item
-    var mappedItem = self._map(item);
+    var mappedItem = self._map === null ? item : self._map(item);
     if (mappedItem !== null) {
       if (!self._optional)
         self._transform(mappedItem, next);

--- a/test/SimpleTransformIterator-test.js
+++ b/test/SimpleTransformIterator-test.js
@@ -536,8 +536,8 @@ describe('SimpleTransformIterator', function () {
         iterator.on('end', done);
       });
 
-      it('should call `read` on the source 10 times', function () {
-        source.read.should.have.callCount(10);
+      it('should call `read` on the source 11 times', function () {
+        source.read.should.have.callCount(11);
       });
 
       it('should result in all items', function () {
@@ -561,8 +561,8 @@ describe('SimpleTransformIterator', function () {
         iterator.on('end', done);
       });
 
-      it('should call `read` on the source 10 times', function () {
-        source.read.should.have.callCount(10);
+      it('should call `read` on the source 11 times', function () {
+        source.read.should.have.callCount(11);
       });
 
       it('should result in skipping the first 5 items', function () {
@@ -611,8 +611,8 @@ describe('SimpleTransformIterator', function () {
         iterator.on('end', done);
       });
 
-      it('should call `read` on the source 10 times', function () {
-        source.read.should.have.callCount(10);
+      it('should call `read` on the source 11 times', function () {
+        source.read.should.have.callCount(11);
       });
 
       it('should result in all items', function () {
@@ -636,8 +636,8 @@ describe('SimpleTransformIterator', function () {
         iterator.on('end', done);
       });
 
-      it('should call `read` on the source 10 times', function () {
-        source.read.should.have.callCount(10);
+      it('should call `read` on the source 11 times', function () {
+        source.read.should.have.callCount(11);
       });
 
       it('should result in all items', function () {
@@ -711,8 +711,8 @@ describe('SimpleTransformIterator', function () {
         iterator.on('end', done);
       });
 
-      it('should call `read` on the source 10 times', function () {
-        source.read.should.have.callCount(10);
+      it('should call `read` on the source 11 times', function () {
+        source.read.should.have.callCount(11);
       });
 
       it('should result in all items', function () {


### PR DESCRIPTION
In #2, I noticed that the `map` operation caused 4 reads of 1 item, instead of 1 read of 4 items. Turns out that `SimpleTransformIterator` awaits the next tick, even if no asynchronous transformation is performed.

This pull request ensures that synchronous transformations are executed directly after one another when possible.