### PR TITLE
Feature/destroy

### DIFF
--- a/asynciterator.js
+++ b/asynciterator.js
@@ -606,7 +606,6 @@ ArrayIterator.prototype._toStringDetails = function () {
 
 /* Called by {@link AsyncIterator#destroy} */
 ArrayIterator.prototype._destroy = function (error, callback) {
-  // Release our complete buffer.
   this._buffer = null;
   callback();
 };
@@ -934,7 +933,6 @@ BufferedIterator.prototype._completeClose = function () {
 
 /* Called by {@link AsyncIterator#destroy} */
 BufferedIterator.prototype._destroy = function (error, callback) {
-  // Release our complete buffer.
   this._buffer = [];
   callback();
 };

--- a/asynciterator.js
+++ b/asynciterator.js
@@ -1092,7 +1092,7 @@ TransformIterator.prototype._closeWhenDone = function () {
 };
 
 /* Cleans up the source iterator and ends. */
-TransformIterator.prototype._end = function () {
+TransformIterator.prototype._end = function (destroy) {
   var source = this._source;
   if (source) {
     source.removeListener('end',      destinationCloseWhenDone);
@@ -1100,7 +1100,7 @@ TransformIterator.prototype._end = function () {
     source.removeListener('readable', destinationFillBuffer);
     delete source._destination;
   }
-  BufferedIterator.prototype._end.call(this);
+  BufferedIterator.prototype._end.call(this, destroy);
 };
 
 /**
@@ -1633,14 +1633,14 @@ ClonedIterator.prototype.read = function () {
 };
 
 /* End the iterator and cleans up. */
-ClonedIterator.prototype._end = function () {
+ClonedIterator.prototype._end = function (destroy) {
   // Unregister from a possible history reader
   var history = this._source && this._source._destination;
   if (history) history.unregister(this);
 
   // Don't call TransformIterator#_end,
   // as it would make the source inaccessible for other clones
-  BufferedIterator.prototype._end.call(this);
+  BufferedIterator.prototype._end.call(this, destroy);
 };
 
 // Disable buffer cleanup

--- a/asynciterator.js
+++ b/asynciterator.js
@@ -826,11 +826,11 @@ BufferedIterator.prototype._read = function (count, done) { done(); };
   @emits AsyncIterator.readable
 **/
 BufferedIterator.prototype._push = function (item) {
-  if (this.done)
-    throw new Error('Cannot push after the iterator was ended.');
-  this._pushedCount++;
-  this._buffer.push(item);
-  this.readable = true;
+  if (!this.done) {
+    this._pushedCount++;
+    this._buffer.push(item);
+    this.readable = true;
+  }
 };
 
 /**

--- a/asynciterator.js
+++ b/asynciterator.js
@@ -24,8 +24,8 @@ var immediate = (function () {
   @type String[]
   @protected
 */
-var STATES = AsyncIterator.STATES = ['INIT', 'OPEN', 'CLOSING', 'CLOSED', 'ENDED'];
-var INIT = 0, OPEN = 1, CLOSING = 2, CLOSED = 3, ENDED = 4;
+var STATES = AsyncIterator.STATES = ['INIT', 'OPEN', 'CLOSING', 'CLOSED', 'ENDED', 'DESTROYED'];
+var INIT = 0, OPEN = 1, CLOSING = 2, CLOSED = 3, ENDED = 4, DESTROYED = 5;
 STATES.forEach(function (state, id) { AsyncIterator[state] = id; });
 
 /**
@@ -69,11 +69,22 @@ STATES.forEach(function (state, id) { AsyncIterator[state] = id; });
 /**
   ID of the ENDED state.
   An iterator has ended if no further items will become available.
+  The 'end' event is guaranteed to have been called when in this state.
 
   @name AsyncIterator.ENDED
   @type integer
   @protected
 */
+
+/**
+ ID of the DESTROYED state.
+ An iterator has been destroyed after calling {@link AsyncIterator#destroy}.
+ The 'end' event has not been called, as pending elements were voided.
+
+ @name AsyncIterator.DESTROYED
+ @type integer
+ @protected
+ */
 
 
 
@@ -210,23 +221,62 @@ AsyncIterator.prototype.close = function () {
 };
 
 /**
+ Destroy the iterator and stop it from generating new items.
+
+ This will not do anything if the iterator was already ended or destroyed.
+
+ All internal resources will be released an no new items will be emitted,
+ even not already generated items.
+
+ Implementors should not override this method,
+ but instead implement {@link AsyncIterator#_destroy}.
+
+ @param {Error} [error] An optional error to emit.
+ @emits AsyncIterator.end
+ @emits AsyncIterator.error Only emitted if an error is passed.
+ **/
+AsyncIterator.prototype.destroy = function (error) {
+  if (!this.done) {
+    var self = this;
+    this._destroy(error, function (errorInner) {
+      error = error || errorInner;
+      if (error)
+        self.emit('error', error);
+      end(self, true);
+    });
+  }
+};
+
+/**
+ Called by {@link AsyncIterator#destroy}.
+ Implementors can override this, but this should not be called directly.
+
+ @param {Error} error A possible error.
+ @param {Function} callback A callback function with an optional error argument.
+ */
+AsyncIterator.prototype._destroy = function (error, callback) {
+  callback();
+};
+
+/**
   Asynchronously ends the iterator and cleans up.
 
   Should never be called before {@link AsyncIterator#close};
   typically, `close` is responsible for calling `_end`.
 
+  @param {boolean} [destroy] If the iterator should be forcefully destroyed.
   @protected
   @emits AsyncIterator.end
 **/
-AsyncIterator.prototype._end = function () {
-  if (this._changeState(ENDED)) {
+AsyncIterator.prototype._end = function (destroy) {
+  if (this._changeState(destroy ? DESTROYED : ENDED)) {
     this._readable = false;
     this.removeAllListeners('readable');
     this.removeAllListeners('data');
     this.removeAllListeners('end');
   }
 };
-function end(self) { self._end(); }
+function end(self, destroy) { self._end(destroy); }
 function endAsync(self) { immediate(end, self); }
 
 /**
@@ -248,7 +298,7 @@ function endAsync(self) { immediate(end, self); }
 Object.defineProperty(AsyncIterator.prototype, 'readable', {
   get: function () { return this._readable; },
   set: function (readable) {
-    readable = !!readable && !this.ended;
+    readable = !!readable && !this.done;
     // Set the readable value only if it has changed
     if (this._readable !== readable) {
       this._readable = readable;
@@ -273,7 +323,7 @@ Object.defineProperty(AsyncIterator.prototype, 'closed', {
 });
 
 /**
-  Gets whether the iterator has stopped emitting items.
+  Gets whether the iterator has finished emitting items.
 
   @name AsyncIterator#ended
   @type boolean
@@ -281,6 +331,31 @@ Object.defineProperty(AsyncIterator.prototype, 'closed', {
 **/
 Object.defineProperty(AsyncIterator.prototype, 'ended', {
   get: function () { return this._state === ENDED; },
+  enumerable: true,
+});
+
+/**
+ Gets whether the iterator has been destroyed.
+
+ @name AsyncIterator#destroyed
+ @type boolean
+ @readonly
+ **/
+Object.defineProperty(AsyncIterator.prototype, 'destroyed', {
+  get: function () { return this._state === DESTROYED; },
+  enumerable: true,
+});
+
+/**
+ Gets whether the iterator will not emit anymore items,
+ either due to being closed or due to being destroyed.
+
+ @name AsyncIterator#done
+ @type boolean
+ @readonly
+ **/
+Object.defineProperty(AsyncIterator.prototype, 'done', {
+  get: function () { return this._state >= ENDED; },
   enumerable: true,
 });
 
@@ -317,7 +392,7 @@ function emitData() {
   while (this._hasListeners('data') && (item = this.read()) !== null)
     this.emit('data', item);
   // Stop draining the source if there are no more `data` listeners
-  if (!this._hasListeners('data')) {
+  if (!this._hasListeners('data') && !this.done) {
     this.removeListener('readable', emitData);
     this._addSingleListener('newListener', waitForDataListener);
   }
@@ -529,6 +604,13 @@ ArrayIterator.prototype._toStringDetails = function () {
   return '(' + (this._buffer && this._buffer.length || 0) + ')';
 };
 
+/* Called by {@link AsyncIterator#destroy} */
+ArrayIterator.prototype._destroy = function (error, callback) {
+  // Release our complete buffer.
+  this._buffer = null;
+  callback();
+};
+
 
 
 /**
@@ -700,7 +782,7 @@ BufferedIterator.prototype._begin = function (done) { done(); };
   @returns {object?} The next item, or `null` if none is available
 **/
 BufferedIterator.prototype.read = function () {
-  if (this.ended)
+  if (this.done)
     return null;
 
   // Try to retrieve an item from the buffer
@@ -744,7 +826,7 @@ BufferedIterator.prototype._read = function (count, done) { done(); };
   @emits AsyncIterator.readable
 **/
 BufferedIterator.prototype._push = function (item) {
-  if (this.ended)
+  if (this.done)
     throw new Error('Cannot push after the iterator was ended.');
   this._pushedCount++;
   this._buffer.push(item);
@@ -848,6 +930,13 @@ BufferedIterator.prototype._completeClose = function () {
         endAsync(self);
     });
   }
+};
+
+/* Called by {@link AsyncIterator#destroy} */
+BufferedIterator.prototype._destroy = function (error, callback) {
+  // Release our complete buffer.
+  this._buffer = [];
+  callback();
 };
 
 /**
@@ -1531,7 +1620,7 @@ function HistoryReader(source) {
 /* Tries to read an item */
 ClonedIterator.prototype.read = function () {
   var source = this._source, item = null;
-  if (!this.ended && source) {
+  if (!this.done && source) {
     // Try to read an item at the current point in history
     var history = source._destination;
     if ((item = history.readAt(this._readPosition)) !== null)

--- a/asynciterator.js
+++ b/asynciterator.js
@@ -132,7 +132,7 @@ function AsyncIterator() {
 **/
 AsyncIterator.prototype._changeState = function (newState, eventAsync) {
   // Validate the state change
-  var valid = newState > this._state;
+  var valid = newState > this._state && this._state < ENDED;
   if (valid) {
     this._state = newState;
     // Emit the `end` event when changing to ENDED

--- a/asynciterator.js
+++ b/asynciterator.js
@@ -606,7 +606,7 @@ ArrayIterator.prototype._toStringDetails = function () {
 
 /* Called by {@link AsyncIterator#destroy} */
 ArrayIterator.prototype._destroy = function (error, callback) {
-  this._buffer = null;
+  delete this._buffer;
   callback();
 };
 

--- a/asynciterator.js
+++ b/asynciterator.js
@@ -231,17 +231,17 @@ AsyncIterator.prototype.close = function () {
  Implementors should not override this method,
  but instead implement {@link AsyncIterator#_destroy}.
 
- @param {Error} [error] An optional error to emit.
+ @param {Error} [cause] An optional error to emit.
  @emits AsyncIterator.end
  @emits AsyncIterator.error Only emitted if an error is passed.
  **/
-AsyncIterator.prototype.destroy = function (error) {
+AsyncIterator.prototype.destroy = function (cause) {
   if (!this.done) {
     var self = this;
-    this._destroy(error, function (errorInner) {
-      error = error || errorInner;
-      if (error)
-        self.emit('error', error);
+    this._destroy(cause, function (error) {
+      cause = cause || error;
+      if (cause)
+        self.emit('error', cause);
       end(self, true);
     });
   }
@@ -249,12 +249,12 @@ AsyncIterator.prototype.destroy = function (error) {
 
 /**
  Called by {@link AsyncIterator#destroy}.
- Implementors can override this, but this should not be called directly.
+ Implementers can override this, but this should not be called directly.
 
- @param {Error} error A possible error.
+ @param {?Error} cause The reason why the iterator is destroyed.
  @param {Function} callback A callback function with an optional error argument.
  */
-AsyncIterator.prototype._destroy = function (error, callback) {
+AsyncIterator.prototype._destroy = function (cause, callback) {
   callback();
 };
 

--- a/test/ArrayIterator-test.js
+++ b/test/ArrayIterator-test.js
@@ -80,6 +80,14 @@ describe('ArrayIterator', function () {
       iterator.ended.should.be.true;
     });
 
+    it('should not have been destroyed', function () {
+      iterator.destroyed.should.be.false;
+    });
+
+    it('should be done', function () {
+      iterator.done.should.be.true;
+    });
+
     it('should not be readable', function () {
       iterator.readable.should.be.false;
     });
@@ -110,6 +118,14 @@ describe('ArrayIterator', function () {
 
     it('should have ended', function () {
       iterator.ended.should.be.true;
+    });
+
+    it('should not have been destroyed', function () {
+      iterator.destroyed.should.be.false;
+    });
+
+    it('should be done', function () {
+      iterator.done.should.be.true;
     });
 
     it('should not be readable', function () {
@@ -146,6 +162,14 @@ describe('ArrayIterator', function () {
 
     it('should have ended', function () {
       iterator.ended.should.be.true;
+    });
+
+    it('should not have been destroyed', function () {
+      iterator.destroyed.should.be.false;
+    });
+
+    it('should be done', function () {
+      iterator.done.should.be.true;
     });
 
     it('should not be readable', function () {
@@ -185,6 +209,14 @@ describe('ArrayIterator', function () {
         iterator.ended.should.be.false;
       });
 
+      it('should not have been destroyed', function () {
+        iterator.destroyed.should.be.false;
+      });
+
+      it('should not be done', function () {
+        iterator.done.should.be.false;
+      });
+
       it('should be readable', function () {
         iterator.readable.should.be.true;
       });
@@ -211,6 +243,14 @@ describe('ArrayIterator', function () {
 
       it('should have ended', function () {
         iterator.ended.should.be.true;
+      });
+
+      it('should not have been destroyed', function () {
+        iterator.destroyed.should.be.false;
+      });
+
+      it('should be done', function () {
+        iterator.done.should.be.true;
       });
 
       it('should not be readable', function () {
@@ -243,6 +283,14 @@ describe('ArrayIterator', function () {
         iterator.ended.should.be.false;
       });
 
+      it('should not have been destroyed', function () {
+        iterator.destroyed.should.be.false;
+      });
+
+      it('should not be done', function () {
+        iterator.done.should.be.false;
+      });
+
       it('should be readable', function () {
         iterator.readable.should.be.true;
       });
@@ -267,6 +315,14 @@ describe('ArrayIterator', function () {
         iterator.ended.should.be.false;
       });
 
+      it('should not have been destroyed', function () {
+        iterator.destroyed.should.be.false;
+      });
+
+      it('should not be done', function () {
+        iterator.done.should.be.false;
+      });
+
       it('should be readable', function () {
         iterator.readable.should.be.true;
       });
@@ -289,6 +345,14 @@ describe('ArrayIterator', function () {
 
       it('should not have ended', function () {
         iterator.ended.should.be.false;
+      });
+
+      it('should not have been destroyed', function () {
+        iterator.destroyed.should.be.false;
+      });
+
+      it('should not be done', function () {
+        iterator.done.should.be.false;
       });
 
       it('should be readable', function () {
@@ -317,6 +381,14 @@ describe('ArrayIterator', function () {
 
       it('should have ended', function () {
         iterator.ended.should.be.true;
+      });
+
+      it('should not have been destroyed', function () {
+        iterator.destroyed.should.be.false;
+      });
+
+      it('should be done', function () {
+        iterator.done.should.be.true;
       });
 
       it('should not be readable', function () {
@@ -349,6 +421,14 @@ describe('ArrayIterator', function () {
         iterator.ended.should.be.false;
       });
 
+      it('should not have been destroyed', function () {
+        iterator.destroyed.should.be.false;
+      });
+
+      it('should not be done', function () {
+        iterator.done.should.be.false;
+      });
+
       it('should be readable', function () {
         iterator.readable.should.be.true;
       });
@@ -373,6 +453,14 @@ describe('ArrayIterator', function () {
         iterator.ended.should.be.false;
       });
 
+      it('should not have been destroyed', function () {
+        iterator.destroyed.should.be.false;
+      });
+
+      it('should not be done', function () {
+        iterator.done.should.be.false;
+      });
+
       it('should be readable', function () {
         iterator.readable.should.be.true;
       });
@@ -395,6 +483,14 @@ describe('ArrayIterator', function () {
 
       it('should not have ended', function () {
         iterator.ended.should.be.false;
+      });
+
+      it('should not have been destroyed', function () {
+        iterator.destroyed.should.be.false;
+      });
+
+      it('should not be done', function () {
+        iterator.done.should.be.false;
       });
 
       it('should be readable', function () {
@@ -425,6 +521,14 @@ describe('ArrayIterator', function () {
         iterator.ended.should.be.true;
       });
 
+      it('should not have been destroyed', function () {
+        iterator.destroyed.should.be.false;
+      });
+
+      it('should be done', function () {
+        iterator.done.should.be.true;
+      });
+
       it('should not be readable', function () {
         iterator.readable.should.be.false;
       });
@@ -447,6 +551,100 @@ describe('ArrayIterator', function () {
 
     it('should return the original items', function () {
       items.should.deep.equal([1, 2, 3, null]);
+    });
+  });
+
+  describe('An ArrayIterator with a two-item array that is destroyed', function () {
+    var iterator;
+    before(function () {
+      iterator = new ArrayIterator([1, 2]);
+      captureEvents(iterator, 'readable', 'end');
+      iterator.destroy();
+    });
+
+    it('should not have emitted a `readable` event', function () {
+      iterator._eventCounts.readable.should.equal(0);
+    });
+
+    it('should not have emitted the `end` event', function () {
+      iterator._eventCounts.end.should.equal(0);
+    });
+
+    it('should not have ended', function () {
+      iterator.ended.should.be.false;
+    });
+
+    it('should have been destroyed', function () {
+      iterator.destroyed.should.be.true;
+    });
+
+    it('should be done', function () {
+      iterator.done.should.be.true;
+    });
+
+    it('should not be readable', function () {
+      iterator.readable.should.be.false;
+    });
+
+    it('cannot be made readable again', function () {
+      iterator.readable = true;
+      iterator.readable.should.be.false;
+    });
+
+    it('should return null when trying to read', function () {
+      expect(iterator.read()).to.be.null;
+    });
+
+    it('should not have any listeners for data, readable, or end', function () {
+      expect(iterator._events).to.not.contain.key('data');
+      expect(iterator._events).to.not.contain.key('readable');
+      expect(iterator._events).to.not.contain.key('end');
+    });
+
+    it('should have an empty buffer', function () {
+      expect(iterator._buffer).to.be.null;
+    });
+
+    describe('after destroy has been called a second time', function () {
+      before(function () { iterator.destroy(); });
+
+      it('should not have emitted a `readable` event', function () {
+        iterator._eventCounts.readable.should.equal(0);
+      });
+
+      it('should not have emitted the `end` event a second time', function () {
+        iterator._eventCounts.end.should.equal(0);
+      });
+
+      it('should not have ended', function () {
+        iterator.ended.should.be.false;
+      });
+
+      it('should have been destroyed', function () {
+        iterator.destroyed.should.be.true;
+      });
+
+      it('should be done', function () {
+        iterator.done.should.be.true;
+      });
+
+      it('should not be readable', function () {
+        iterator.readable.should.be.false;
+      });
+
+      it('should return null when trying to read', function () {
+        expect(iterator.read()).to.be.null;
+      });
+
+      it('should not have any listeners for data, readable, or end', function () {
+        expect(iterator._events).to.not.contain.key('data');
+        expect(iterator._events).to.not.contain.key('readable');
+        expect(iterator._events).to.not.contain.key('end');
+      });
+
+      it('should have an empty buffer', function () {
+        expect(iterator._buffer).to.be.null;
+      });
     });
   });
 });

--- a/test/ArrayIterator-test.js
+++ b/test/ArrayIterator-test.js
@@ -602,7 +602,7 @@ describe('ArrayIterator', function () {
     });
 
     it('should have an empty buffer', function () {
-      expect(iterator._buffer).to.be.null;
+      expect(iterator._buffer).to.be.an('undefined');
     });
 
     describe('after destroy has been called a second time', function () {
@@ -643,7 +643,7 @@ describe('ArrayIterator', function () {
       });
 
       it('should have an empty buffer', function () {
-        expect(iterator._buffer).to.be.null;
+        expect(iterator._buffer).to.be.an('undefined');
       });
     });
   });

--- a/test/AsyncIterator-test.js
+++ b/test/AsyncIterator-test.js
@@ -68,6 +68,14 @@ describe('AsyncIterator', function () {
       iterator.ended.should.be.false;
     });
 
+    it('should not have been destroyed', function () {
+      iterator.destroyed.should.be.false;
+    });
+
+    it('should not be done', function () {
+      iterator.done.should.be.false;
+    });
+
     it('should not be readable', function () {
       iterator.readable.should.be.false;
     });
@@ -111,6 +119,57 @@ describe('AsyncIterator', function () {
         iterator.ended.should.be.true;
       });
 
+      it('should not have been destroyed', function () {
+        iterator.destroyed.should.be.false;
+      });
+
+      it('should be done', function () {
+        iterator.done.should.be.true;
+      });
+
+      it('should not be readable', function () {
+        iterator.readable.should.be.false;
+      });
+
+      it('cannot be made readable again', function () {
+        iterator.readable = true;
+        iterator.readable.should.be.false;
+      });
+
+      it('should return null when trying to read', function () {
+        expect(iterator.read()).to.be.null;
+      });
+
+      it('should not have any listeners for data, readable, or end', function () {
+        expect(iterator._events).to.not.contain.key('data');
+        expect(iterator._events).to.not.contain.key('readable');
+        expect(iterator._events).to.not.contain.key('end');
+      });
+    });
+
+    describe('after destroy has been called', function () {
+      before(function () { iterator.destroy(); });
+
+      it('should not have emitted another `readable` event', function () {
+        iterator._eventCounts.readable.should.equal(1);
+      });
+
+      it('should have emitted the `end` event', function () {
+        iterator._eventCounts.end.should.equal(1);
+      });
+
+      it('should have ended', function () {
+        iterator.ended.should.be.true;
+      });
+
+      it('should not have been destroyed', function () {
+        iterator.destroyed.should.be.false;
+      });
+
+      it('should be done', function () {
+        iterator.done.should.be.true;
+      });
+
       it('should not be readable', function () {
         iterator.readable.should.be.false;
       });
@@ -146,6 +205,14 @@ describe('AsyncIterator', function () {
         iterator.ended.should.be.true;
       });
 
+      it('should not have been destroyed', function () {
+        iterator.destroyed.should.be.false;
+      });
+
+      it('should be done', function () {
+        iterator.done.should.be.true;
+      });
+
       it('should not be readable', function () {
         iterator.readable.should.be.false;
       });
@@ -159,6 +226,196 @@ describe('AsyncIterator', function () {
         expect(iterator._events).to.not.contain.key('readable');
         expect(iterator._events).to.not.contain.key('end');
       });
+    });
+  });
+
+  describe('A default AsyncIterator instance that is destroyed', function () {
+    var iterator;
+    before(function () {
+      iterator = new AsyncIterator();
+      captureEvents(iterator, 'data', 'readable', 'end');
+      iterator.destroy();
+    });
+
+    it('should not have emitted a `readable` event', function () {
+      iterator._eventCounts.readable.should.equal(0);
+    });
+
+    it('should not have emitted the `end` event', function () {
+      iterator._eventCounts.end.should.equal(0);
+    });
+
+    it('should not have ended', function () {
+      iterator.ended.should.be.false;
+    });
+
+    it('should have been destroyed', function () {
+      iterator.destroyed.should.be.true;
+    });
+
+    it('should be done', function () {
+      iterator.done.should.be.true;
+    });
+
+    it('should not be readable', function () {
+      iterator.readable.should.be.false;
+    });
+
+    it('cannot be made readable again', function () {
+      iterator.readable = true;
+      iterator.readable.should.be.false;
+    });
+
+    it('should return null when trying to read', function () {
+      expect(iterator.read()).to.be.null;
+    });
+
+    it('should not have any listeners for data, readable, or end', function () {
+      expect(iterator._events).to.not.contain.key('data');
+      expect(iterator._events).to.not.contain.key('readable');
+      expect(iterator._events).to.not.contain.key('end');
+    });
+
+    describe('after destroy has been called a second time', function () {
+      before(function () { iterator.destroy(); });
+
+      it('should not have emitted a `readable` event', function () {
+        iterator._eventCounts.readable.should.equal(0);
+      });
+
+      it('should still not have emitted the `end` event', function () {
+        iterator._eventCounts.end.should.equal(0);
+      });
+
+      it('should not have ended', function () {
+        iterator.ended.should.be.false;
+      });
+
+      it('should have been destroyed', function () {
+        iterator.destroyed.should.be.true;
+      });
+
+      it('should be done', function () {
+        iterator.done.should.be.true;
+      });
+
+      it('should not be readable', function () {
+        iterator.readable.should.be.false;
+      });
+
+      it('should return null when trying to read', function () {
+        expect(iterator.read()).to.be.null;
+      });
+
+      it('should not have any listeners for data, readable, or end', function () {
+        expect(iterator._events).to.not.contain.key('data');
+        expect(iterator._events).to.not.contain.key('readable');
+        expect(iterator._events).to.not.contain.key('end');
+      });
+    });
+  });
+
+  describe('A default AsyncIterator instance that is destroyed with a given error', function () {
+    var iterator, err;
+    before(function () {
+      iterator = new AsyncIterator();
+      err = new Error('Some error');
+      captureEvents(iterator, 'data', 'readable', 'end', 'error');
+      iterator.destroy(err);
+    });
+
+    it('should not have emitted a `readable` event', function () {
+      iterator._eventCounts.readable.should.equal(0);
+    });
+
+    it('should not have emitted the `end` event', function () {
+      iterator._eventCounts.end.should.equal(0);
+    });
+
+    it('should have emitted the `error` event', function () {
+      iterator._eventCounts.error.should.equal(1);
+    });
+
+    it('should not have ended', function () {
+      iterator.ended.should.be.false;
+    });
+
+    it('should have been destroyed', function () {
+      iterator.destroyed.should.be.true;
+    });
+
+    it('should be done', function () {
+      iterator.done.should.be.true;
+    });
+
+    it('should not be readable', function () {
+      iterator.readable.should.be.false;
+    });
+
+    it('cannot be made readable again', function () {
+      iterator.readable = true;
+      iterator.readable.should.be.false;
+    });
+
+    it('should return null when trying to read', function () {
+      expect(iterator.read()).to.be.null;
+    });
+
+    it('should not have any listeners for data, readable, or end', function () {
+      expect(iterator._events).to.not.contain.key('data');
+      expect(iterator._events).to.not.contain.key('readable');
+      expect(iterator._events).to.not.contain.key('end');
+    });
+  });
+
+  describe('A default AsyncIterator instance that is destroyed asynchronously', function () {
+    var iterator;
+    before(function () {
+      iterator = new AsyncIterator();
+      captureEvents(iterator, 'data', 'readable', 'end');
+      iterator._destroy = function (error, callback) {
+        setImmediate(callback);
+      };
+      iterator.destroy();
+    });
+
+    it('should not have emitted a `readable` event', function () {
+      iterator._eventCounts.readable.should.equal(0);
+    });
+
+    it('should not have emitted the `end` event', function () {
+      iterator._eventCounts.end.should.equal(0);
+    });
+
+    it('should not have ended', function () {
+      iterator.ended.should.be.false;
+    });
+
+    it('should have been destroyed', function () {
+      iterator.destroyed.should.be.true;
+    });
+
+    it('should be done', function () {
+      iterator.done.should.be.true;
+    });
+
+    it('should not be readable', function () {
+      iterator.readable.should.be.false;
+    });
+
+    it('cannot be made readable again', function () {
+      iterator.readable = true;
+      iterator.readable.should.be.false;
+    });
+
+    it('should return null when trying to read', function () {
+      expect(iterator.read()).to.be.null;
+    });
+
+    it('should not have any listeners for data, readable, or end', function () {
+      expect(iterator._events).to.not.contain.key('data');
+      expect(iterator._events).to.not.contain.key('readable');
+      expect(iterator._events).to.not.contain.key('end');
     });
   });
 
@@ -351,6 +608,82 @@ describe('AsyncIterator', function () {
     describe('after the iterator is closed', function () {
       before(function () {
         iterator.close();
+      });
+
+      it('should not have listeners for the `data` event', function () {
+        EventEmitter.listenerCount(iterator, 'readable').should.equal(0);
+      });
+
+      it('should not be listening for the `readable` event', function () {
+        EventEmitter.listenerCount(iterator, 'readable').should.equal(0);
+      });
+
+      it('should not be listening for the `newListener` event', function () {
+        EventEmitter.listenerCount(iterator, 'newListener').should.equal(0);
+      });
+    });
+  });
+
+  describe('An AsyncIterator instance to which 2 items are added an will be destroyed', function () {
+    var iterator, items = [], dataListener1;
+    before(function () {
+      iterator = new AsyncIterator();
+      iterator.readable = true;
+      iterator.read = sinon.spy(function () { return items.shift() || null; });
+
+      items.push(1, 2);
+      iterator.emit('readable');
+    });
+
+    describe('after the iterator is destroyed', function () {
+      before(function () {
+        iterator.on('data', dataListener1 = sinon.spy());
+        iterator.destroy();
+      });
+
+      it('should not have emitted the `data` event for both items', function () {
+        dataListener1.should.have.callCount(0);
+      });
+
+      it('should not have listeners for the `data` event', function () {
+        EventEmitter.listenerCount(iterator, 'readable').should.equal(0);
+      });
+
+      it('should not be listening for the `readable` event', function () {
+        EventEmitter.listenerCount(iterator, 'readable').should.equal(0);
+      });
+
+      it('should not be listening for the `newListener` event', function () {
+        EventEmitter.listenerCount(iterator, 'newListener').should.equal(0);
+      });
+    });
+  });
+
+  describe('An AsyncIterator instance to which 2 items are added an will be destroyed with an error', function () {
+    var iterator, items = [], err, dataListener1, errorListener1;
+    before(function () {
+      iterator = new AsyncIterator();
+      iterator.readable = true;
+      iterator.read = sinon.spy(function () { return items.shift() || null; });
+
+      items.push(1, 2);
+      iterator.emit('readable');
+    });
+
+    describe('after the iterator is destroyed with an error', function () {
+      before(function () {
+        err = new Error('My error');
+        iterator.on('data', dataListener1 = sinon.spy());
+        iterator.on('error', errorListener1 = sinon.spy());
+        iterator.destroy(err);
+      });
+
+      it('should not have emitted the `data` event for both items', function () {
+        dataListener1.should.have.callCount(0);
+      });
+
+      it('should have emitted the `error` event', function () {
+        errorListener1.should.have.callCount(1);
       });
 
       it('should not have listeners for the `data` event', function () {

--- a/test/AsyncIterator-test.js
+++ b/test/AsyncIterator-test.js
@@ -229,6 +229,51 @@ describe('AsyncIterator', function () {
     });
   });
 
+  describe('A default AsyncIterator instance', function () {
+    var iterator;
+    before(function () {
+      iterator = new AsyncIterator();
+    });
+
+    describe('when in OPEN state', function () {
+      it('cannot transition to OPEN state', function () {
+        expect(iterator._changeState(AsyncIterator.OPEN)).to.be.false;
+      });
+
+      it('can transition to CLOSED state', function () {
+        expect(iterator._changeState(AsyncIterator.CLOSED)).to.be.true;
+      });
+    });
+
+    describe('when in CLOSED state', function () {
+      before(function () {
+        iterator._changeState(AsyncIterator.CLOSED);
+      });
+
+      it('cannot transition to CLOSED state', function () {
+        expect(iterator._changeState(AsyncIterator.CLOSED)).to.be.false;
+      });
+
+      it('can transition to ENDED state', function () {
+        expect(iterator._changeState(AsyncIterator.ENDED)).to.be.true;
+      });
+    });
+
+    describe('when in ENDED state', function () {
+      before(function () {
+        iterator._changeState(AsyncIterator.ENDED);
+      });
+
+      it('cannot transition to ENDED state', function () {
+        expect(iterator._changeState(AsyncIterator.ENDED)).to.be.false;
+      });
+
+      it('cannot transition to DESTROYED state', function () {
+        expect(iterator._changeState(AsyncIterator.DESTROYED)).to.be.false;
+      });
+    });
+  });
+
   describe('A default AsyncIterator instance that is destroyed', function () {
     var iterator;
     before(function () {

--- a/test/AsyncIterator-test.js
+++ b/test/AsyncIterator-test.js
@@ -625,7 +625,7 @@ describe('AsyncIterator', function () {
   });
 
   describe('An AsyncIterator instance to which 2 items are added an will be destroyed', function () {
-    var iterator, items = [], dataListener1;
+    var iterator, items = [], dataListener;
     before(function () {
       iterator = new AsyncIterator();
       iterator.readable = true;
@@ -637,12 +637,12 @@ describe('AsyncIterator', function () {
 
     describe('after the iterator is destroyed', function () {
       before(function () {
-        iterator.on('data', dataListener1 = sinon.spy());
+        iterator.on('data', dataListener = sinon.spy());
         iterator.destroy();
       });
 
       it('should not have emitted the `data` event for both items', function () {
-        dataListener1.should.have.callCount(0);
+        dataListener.should.have.callCount(0);
       });
 
       it('should not have listeners for the `data` event', function () {
@@ -660,7 +660,7 @@ describe('AsyncIterator', function () {
   });
 
   describe('An AsyncIterator instance to which 2 items are added an will be destroyed with an error', function () {
-    var iterator, items = [], err, dataListener1, errorListener1;
+    var iterator, items = [], err, dataListener, errorListener;
     before(function () {
       iterator = new AsyncIterator();
       iterator.readable = true;
@@ -673,17 +673,17 @@ describe('AsyncIterator', function () {
     describe('after the iterator is destroyed with an error', function () {
       before(function () {
         err = new Error('My error');
-        iterator.on('data', dataListener1 = sinon.spy());
-        iterator.on('error', errorListener1 = sinon.spy());
+        iterator.on('data', dataListener = sinon.spy());
+        iterator.on('error', errorListener = sinon.spy());
         iterator.destroy(err);
       });
 
       it('should not have emitted the `data` event for both items', function () {
-        dataListener1.should.have.callCount(0);
+        dataListener.should.have.callCount(0);
       });
 
       it('should have emitted the `error` event', function () {
-        errorListener1.should.have.callCount(1);
+        errorListener.should.have.callCount(1);
       });
 
       it('should not have listeners for the `data` event', function () {

--- a/test/BufferedIterator-test.js
+++ b/test/BufferedIterator-test.js
@@ -2521,4 +2521,57 @@ describe('BufferedIterator', function () {
       expect(iterator._events).to.not.contain.key('end');
     });
   });
+
+  describe('A BufferedIterator that is destroyed after the first item but before the next call', function () {
+    var iterator, i = 0;
+    before(function () {
+      iterator = new BufferedIterator();
+      iterator._read = sinon.spy(function (count, next) {
+        this._push(++i);
+        if (i === 1)
+          iterator.destroy();
+        next();
+      });
+      captureEvents(iterator, 'data', 'end', 'readable');
+    });
+
+    it('should have called _read() once', function () {
+      iterator._read.should.have.callCount(1);
+    });
+
+    it('should have an empty buffer', function () {
+      iterator._buffer.length.should.equal(0);
+    });
+
+    it('should not have ended', function () {
+      iterator.ended.should.be.false;
+    });
+
+    it('should have been destroyed', function () {
+      iterator.destroyed.should.be.true;
+    });
+
+    it('should be done', function () {
+      iterator.done.should.be.true;
+    });
+
+    it('should not be readable', function () {
+      iterator.readable.should.be.false;
+    });
+
+    it('cannot be made readable again', function () {
+      iterator.readable = true;
+      iterator.readable.should.be.false;
+    });
+
+    it('should return null when trying to read', function () {
+      expect(iterator.read()).to.be.null;
+    });
+
+    it('should not have any listeners for data, readable, or end', function () {
+      expect(iterator._events).to.not.contain.key('data');
+      expect(iterator._events).to.not.contain.key('readable');
+      expect(iterator._events).to.not.contain.key('end');
+    });
+  });
 });

--- a/test/BufferedIterator-test.js
+++ b/test/BufferedIterator-test.js
@@ -67,6 +67,14 @@ describe('BufferedIterator', function () {
       iterator.ended.should.be.false;
     });
 
+    it('should not have been destroyed', function () {
+      iterator.destroyed.should.be.false;
+    });
+
+    it('should not be done', function () {
+      iterator.done.should.be.false;
+    });
+
     it('should not be readable', function () {
       iterator.readable.should.be.false;
     });
@@ -84,8 +92,16 @@ describe('BufferedIterator', function () {
         iterator._eventCounts.end.should.equal(1);
       });
 
-      it('should nhave ended', function () {
+      it('should have ended', function () {
         iterator.ended.should.be.true;
+      });
+
+      it('should not have been destroyed', function () {
+        iterator.destroyed.should.be.false;
+      });
+
+      it('should be done', function () {
+        iterator.done.should.be.true;
       });
 
       it('should not be readable', function () {
@@ -124,6 +140,14 @@ describe('BufferedIterator', function () {
           iterator.ended.should.be.false;
         });
 
+        it('should not have been destroyed', function () {
+          iterator.destroyed.should.be.false;
+        });
+
+        it('should not be done', function () {
+          iterator.done.should.be.false;
+        });
+
         it('should be readable', function () {
           iterator.readable.should.be.true;
         });
@@ -151,6 +175,14 @@ describe('BufferedIterator', function () {
 
         it('should have ended', function () {
           iterator.ended.should.be.true;
+        });
+
+        it('should not have been destroyed', function () {
+          iterator.destroyed.should.be.false;
+        });
+
+        it('should be done', function () {
+          iterator.done.should.be.true;
         });
 
         it('should not be readable', function () {
@@ -183,6 +215,14 @@ describe('BufferedIterator', function () {
           iterator.ended.should.be.true;
         });
 
+        it('should not have been destroyed', function () {
+          iterator.destroyed.should.be.false;
+        });
+
+        it('should be done', function () {
+          iterator.done.should.be.true;
+        });
+
         it('should not be readable', function () {
           iterator.readable.should.be.false;
         });
@@ -208,6 +248,14 @@ describe('BufferedIterator', function () {
 
         it('should have ended', function () {
           iterator.ended.should.be.true;
+        });
+
+        it('should not have been destroyed', function () {
+          iterator.destroyed.should.be.false;
+        });
+
+        it('should be done', function () {
+          iterator.done.should.be.true;
         });
 
         it('should not be readable', function () {
@@ -238,6 +286,14 @@ describe('BufferedIterator', function () {
 
         it('should have ended', function () {
           iterator.ended.should.be.true;
+        });
+
+        it('should not have been destroyed', function () {
+          iterator.destroyed.should.be.false;
+        });
+
+        it('should be done', function () {
+          iterator.done.should.be.true;
         });
 
         it('should not be readable', function () {
@@ -278,6 +334,14 @@ describe('BufferedIterator', function () {
           iterator.ended.should.be.false;
         });
 
+        it('should not have been destroyed', function () {
+          iterator.destroyed.should.be.false;
+        });
+
+        it('should not be done', function () {
+          iterator.done.should.be.false;
+        });
+
         it('should be readable', function () {
           iterator.readable.should.be.true;
         });
@@ -305,6 +369,14 @@ describe('BufferedIterator', function () {
 
         it('should have ended', function () {
           iterator.ended.should.be.true;
+        });
+
+        it('should not have been destroyed', function () {
+          iterator.destroyed.should.be.false;
+        });
+
+        it('should be done', function () {
+          iterator.done.should.be.true;
         });
 
         it('should not be readable', function () {
@@ -337,6 +409,14 @@ describe('BufferedIterator', function () {
           iterator.ended.should.be.true;
         });
 
+        it('should not have been destroyed', function () {
+          iterator.destroyed.should.be.false;
+        });
+
+        it('should be done', function () {
+          iterator.done.should.be.true;
+        });
+
         it('should not be readable', function () {
           iterator.readable.should.be.false;
         });
@@ -362,6 +442,14 @@ describe('BufferedIterator', function () {
 
         it('should have ended', function () {
           iterator.ended.should.be.true;
+        });
+
+        it('should not have been destroyed', function () {
+          iterator.destroyed.should.be.false;
+        });
+
+        it('should be done', function () {
+          iterator.done.should.be.true;
         });
 
         it('should not be readable', function () {
@@ -392,6 +480,14 @@ describe('BufferedIterator', function () {
 
         it('should have ended', function () {
           iterator.ended.should.be.true;
+        });
+
+        it('should not have been destroyed', function () {
+          iterator.destroyed.should.be.false;
+        });
+
+        it('should be done', function () {
+          iterator.done.should.be.true;
         });
 
         it('should not be readable', function () {
@@ -429,6 +525,14 @@ describe('BufferedIterator', function () {
         iterator.ended.should.be.false;
       });
 
+      it('should not have been destroyed', function () {
+        iterator.destroyed.should.be.false;
+      });
+
+      it('should not be done', function () {
+        iterator.done.should.be.false;
+      });
+
       it('should return null on read', function () {
         expect(iterator.read()).to.be.null;
       });
@@ -447,6 +551,14 @@ describe('BufferedIterator', function () {
 
       it('should have ended', function () {
         iterator.ended.should.be.true;
+      });
+
+      it('should not have been destroyed', function () {
+        iterator.destroyed.should.be.false;
+      });
+
+      it('should be done', function () {
+        iterator.done.should.be.true;
       });
 
       it('should return null on read', function () {
@@ -480,6 +592,14 @@ describe('BufferedIterator', function () {
           iterator.ended.should.be.false;
         });
 
+        it('should not have been destroyed', function () {
+          iterator.destroyed.should.be.false;
+        });
+
+        it('should not be done', function () {
+          iterator.done.should.be.false;
+        });
+
         it('should not have called `_read`', function () {
           iterator._read.should.have.callCount(0);
         });
@@ -499,6 +619,14 @@ describe('BufferedIterator', function () {
 
         it('should have ended', function () {
           iterator.ended.should.be.true;
+        });
+
+        it('should not have been destroyed', function () {
+          iterator.destroyed.should.be.false;
+        });
+
+        it('should be done', function () {
+          iterator.done.should.be.true;
         });
 
         it('should not have called `_read`', function () {
@@ -523,6 +651,14 @@ describe('BufferedIterator', function () {
           iterator.ended.should.be.false;
         });
 
+        it('should not have been destroyed', function () {
+          iterator.destroyed.should.be.false;
+        });
+
+        it('should not be done', function () {
+          iterator.done.should.be.false;
+        });
+
         it('should not have called `_read`', function () {
           iterator._read.should.have.callCount(0);
         });
@@ -541,6 +677,14 @@ describe('BufferedIterator', function () {
 
         it('should have ended', function () {
           iterator.ended.should.be.true;
+        });
+
+        it('should not have been destroyed', function () {
+          iterator.destroyed.should.be.false;
+        });
+
+        it('should be done', function () {
+          iterator.done.should.be.true;
         });
 
         it('should have called `_read` once', function () {
@@ -567,6 +711,14 @@ describe('BufferedIterator', function () {
 
         it('should not have ended', function () {
           iterator.ended.should.be.false;
+        });
+
+        it('should not have been destroyed', function () {
+          iterator.destroyed.should.be.false;
+        });
+
+        it('should not be done', function () {
+          iterator.done.should.be.false;
         });
 
         it('should be readable', function () {
@@ -601,6 +753,14 @@ describe('BufferedIterator', function () {
           iterator.ended.should.be.false;
         });
 
+        it('should not have been destroyed', function () {
+          iterator.destroyed.should.be.false;
+        });
+
+        it('should not be done', function () {
+          iterator.done.should.be.false;
+        });
+
         it('should be readable', function () {
           iterator.readable.should.be.true;
         });
@@ -624,6 +784,14 @@ describe('BufferedIterator', function () {
 
         it('should not have ended', function () {
           iterator.ended.should.be.false;
+        });
+
+        it('should not have been destroyed', function () {
+          iterator.destroyed.should.be.false;
+        });
+
+        it('should not be done', function () {
+          iterator.done.should.be.false;
         });
 
         it('should be readable', function () {
@@ -654,6 +822,14 @@ describe('BufferedIterator', function () {
           iterator.ended.should.be.false;
         });
 
+        it('should not have been destroyed', function () {
+          iterator.destroyed.should.be.false;
+        });
+
+        it('should not be done', function () {
+          iterator.done.should.be.false;
+        });
+
         it('should be readable', function () {
           iterator.readable.should.be.true;
         });
@@ -676,6 +852,14 @@ describe('BufferedIterator', function () {
 
         it('should have ended', function () {
           iterator.ended.should.be.true;
+        });
+
+        it('should not have been destroyed', function () {
+          iterator.destroyed.should.be.false;
+        });
+
+        it('should be done', function () {
+          iterator.done.should.be.true;
         });
 
         it('should not be readable', function () {
@@ -708,6 +892,14 @@ describe('BufferedIterator', function () {
           iterator.ended.should.be.false;
         });
 
+        it('should not have been destroyed', function () {
+          iterator.destroyed.should.be.false;
+        });
+
+        it('should not be done', function () {
+          iterator.done.should.be.false;
+        });
+
         it('should be readable', function () {
           iterator.readable.should.be.true;
         });
@@ -736,6 +928,14 @@ describe('BufferedIterator', function () {
           iterator.ended.should.be.false;
         });
 
+        it('should not have been destroyed', function () {
+          iterator.destroyed.should.be.false;
+        });
+
+        it('should not be done', function () {
+          iterator.done.should.be.false;
+        });
+
         it('should be readable', function () {
           iterator.readable.should.be.true;
         });
@@ -758,6 +958,14 @@ describe('BufferedIterator', function () {
 
         it('should not have ended', function () {
           iterator.ended.should.be.false;
+        });
+
+        it('should not have been destroyed', function () {
+          iterator.destroyed.should.be.false;
+        });
+
+        it('should not be done', function () {
+          iterator.done.should.be.false;
         });
 
         it('should be readable', function () {
@@ -783,6 +991,14 @@ describe('BufferedIterator', function () {
 
         it('should not have ended', function () {
           iterator.ended.should.be.false;
+        });
+
+        it('should not have been destroyed', function () {
+          iterator.destroyed.should.be.false;
+        });
+
+        it('should not be done', function () {
+          iterator.done.should.be.false;
         });
 
         it('should be readable', function () {
@@ -811,6 +1027,14 @@ describe('BufferedIterator', function () {
 
         it('should have ended', function () {
           iterator.ended.should.be.true;
+        });
+
+        it('should not have been destroyed', function () {
+          iterator.destroyed.should.be.false;
+        });
+
+        it('should be done', function () {
+          iterator.done.should.be.true;
         });
 
         it('should not be readable', function () {
@@ -857,6 +1081,14 @@ describe('BufferedIterator', function () {
           iterator.ended.should.be.false;
         });
 
+        it('should not have been destroyed', function () {
+          iterator.destroyed.should.be.false;
+        });
+
+        it('should not be done', function () {
+          iterator.done.should.be.false;
+        });
+
         it('should be readable', function () {
           iterator.readable.should.be.true;
         });
@@ -884,6 +1116,14 @@ describe('BufferedIterator', function () {
 
         it('should not have ended', function () {
           iterator.ended.should.be.false;
+        });
+
+        it('should not have been destroyed', function () {
+          iterator.destroyed.should.be.false;
+        });
+
+        it('should not be done', function () {
+          iterator.done.should.be.false;
         });
 
         it('should be readable', function () {
@@ -916,6 +1156,14 @@ describe('BufferedIterator', function () {
           iterator.ended.should.be.true;
         });
 
+        it('should not have been destroyed', function () {
+          iterator.destroyed.should.be.false;
+        });
+
+        it('should be done', function () {
+          iterator.done.should.be.true;
+        });
+
         it('should not be readable', function () {
           iterator.readable.should.be.false;
         });
@@ -944,6 +1192,14 @@ describe('BufferedIterator', function () {
 
         it('should have ended', function () {
           iterator.ended.should.be.true;
+        });
+
+        it('should not have been destroyed', function () {
+          iterator.destroyed.should.be.false;
+        });
+
+        it('should be done', function () {
+          iterator.done.should.be.true;
         });
 
         it('should not be readable', function () {
@@ -977,6 +1233,14 @@ describe('BufferedIterator', function () {
           iterator.ended.should.be.false;
         });
 
+        it('should not have been destroyed', function () {
+          iterator.destroyed.should.be.false;
+        });
+
+        it('should not be done', function () {
+          iterator.done.should.be.false;
+        });
+
         it('should be readable', function () {
           iterator.readable.should.be.true;
         });
@@ -1005,6 +1269,14 @@ describe('BufferedIterator', function () {
 
         it('should have ended', function () {
           iterator.ended.should.be.true;
+        });
+
+        it('should not have been destroyed', function () {
+          iterator.destroyed.should.be.false;
+        });
+
+        it('should be done', function () {
+          iterator.done.should.be.true;
         });
 
         it('should not be readable', function () {
@@ -1052,6 +1324,14 @@ describe('BufferedIterator', function () {
 
         it('should not have ended', function () {
           iterator.ended.should.be.false;
+        });
+
+        it('should not have been destroyed', function () {
+          iterator.destroyed.should.be.false;
+        });
+
+        it('should not be done', function () {
+          iterator.done.should.be.false;
         });
 
         it('should be readable', function () {
@@ -1210,6 +1490,14 @@ describe('BufferedIterator', function () {
         iterator.ended.should.be.false;
       });
 
+      it('should not have been destroyed', function () {
+        iterator.destroyed.should.be.false;
+      });
+
+      it('should not be done', function () {
+        iterator.done.should.be.false;
+      });
+
       it('should be readable', function () {
         iterator.readable.should.be.true;
       });
@@ -1238,6 +1526,14 @@ describe('BufferedIterator', function () {
         iterator.ended.should.be.false;
       });
 
+      it('should not have been destroyed', function () {
+        iterator.destroyed.should.be.false;
+      });
+
+      it('should not be done', function () {
+        iterator.done.should.be.false;
+      });
+
       it('should be readable', function () {
         iterator.readable.should.be.true;
       });
@@ -1261,6 +1557,14 @@ describe('BufferedIterator', function () {
 
       it('should have ended', function () {
         iterator.ended.should.be.true;
+      });
+
+      it('should not have been destroyed', function () {
+        iterator.destroyed.should.be.false;
+      });
+
+      it('should be done', function () {
+        iterator.done.should.be.true;
       });
 
       it('should not be readable', function () {
@@ -1367,6 +1671,14 @@ describe('BufferedIterator', function () {
         iterator.ended.should.be.false;
       });
 
+      it('should not have been destroyed', function () {
+        iterator.destroyed.should.be.false;
+      });
+
+      it('should not be done', function () {
+        iterator.done.should.be.false;
+      });
+
       it('should be readable', function () {
         iterator.readable.should.be.true;
       });
@@ -1395,6 +1707,14 @@ describe('BufferedIterator', function () {
         iterator.ended.should.be.false;
       });
 
+      it('should not have been destroyed', function () {
+        iterator.destroyed.should.be.false;
+      });
+
+      it('should not be done', function () {
+        iterator.done.should.be.false;
+      });
+
       it('should be readable', function () {
         iterator.readable.should.be.true;
       });
@@ -1418,6 +1738,14 @@ describe('BufferedIterator', function () {
 
       it('should have ended', function () {
         iterator.ended.should.be.true;
+      });
+
+      it('should not have been destroyed', function () {
+        iterator.destroyed.should.be.false;
+      });
+
+      it('should be done', function () {
+        iterator.done.should.be.true;
       });
 
       it('should not be readable', function () {
@@ -1474,6 +1802,14 @@ describe('BufferedIterator', function () {
       iterator.ended.should.be.false;
     });
 
+    it('should not have been destroyed', function () {
+      iterator.destroyed.should.be.false;
+    });
+
+    it('should not be done', function () {
+      iterator.done.should.be.false;
+    });
+
     it('should be readable after reading', function () {
       iterator.readable.should.be.false;
     });
@@ -1517,6 +1853,14 @@ describe('BufferedIterator', function () {
         iterator.ended.should.be.false;
       });
 
+      it('should not have been destroyed', function () {
+        iterator.destroyed.should.be.false;
+      });
+
+      it('should not be done', function () {
+        iterator.done.should.be.false;
+      });
+
       it('should be readable', function () {
         iterator.readable.should.be.true;
       });
@@ -1540,6 +1884,14 @@ describe('BufferedIterator', function () {
 
       it('should not have ended', function () {
         iterator.ended.should.be.false;
+      });
+
+      it('should not have been destroyed', function () {
+        iterator.destroyed.should.be.false;
+      });
+
+      it('should not be done', function () {
+        iterator.done.should.be.false;
       });
 
       it('should be readable', function () {
@@ -1568,6 +1920,14 @@ describe('BufferedIterator', function () {
 
       it('should have ended', function () {
         iterator.ended.should.be.true;
+      });
+
+      it('should not have been destroyed', function () {
+        iterator.destroyed.should.be.false;
+      });
+
+      it('should be done', function () {
+        iterator.done.should.be.true;
       });
 
       it('should not be readable', function () {
@@ -1616,6 +1976,14 @@ describe('BufferedIterator', function () {
         iterator.ended.should.be.false;
       });
 
+      it('should not have been destroyed', function () {
+        iterator.destroyed.should.be.false;
+      });
+
+      it('should not be done', function () {
+        iterator.done.should.be.false;
+      });
+
       it('should be readable', function () {
         iterator.readable.should.be.true;
       });
@@ -1639,6 +2007,14 @@ describe('BufferedIterator', function () {
 
       it('should not have ended', function () {
         iterator.ended.should.be.false;
+      });
+
+      it('should not have been destroyed', function () {
+        iterator.destroyed.should.be.false;
+      });
+
+      it('should not be done', function () {
+        iterator.done.should.be.false;
       });
 
       it('should be readable', function () {
@@ -1667,6 +2043,14 @@ describe('BufferedIterator', function () {
 
       it('should have ended', function () {
         iterator.ended.should.be.true;
+      });
+
+      it('should not have been destroyed', function () {
+        iterator.destroyed.should.be.false;
+      });
+
+      it('should be done', function () {
+        iterator.done.should.be.true;
       });
 
       it('should not be readable', function () {
@@ -1718,6 +2102,190 @@ describe('BufferedIterator', function () {
 
     it('should not have ended', function () {
       iterator.ended.should.be.false;
+    });
+
+    it('should not have been destroyed', function () {
+      iterator.destroyed.should.be.false;
+    });
+
+    it('should not be done', function () {
+      iterator.done.should.be.false;
+    });
+  });
+
+  describe('A BufferedIterator with a synchronous flush that is destroyed', function () {
+    var iterator;
+    before(function () {
+      iterator = new BufferedIterator({ maxBufferSize: 1 });
+      iterator._read = function (item, done) {
+        this._push('a');
+        done();
+      };
+      iterator._flush = function (done) {
+        this._push('x');
+        this._push('y');
+        done();
+      };
+      captureEvents(iterator, 'readable', 'end');
+    });
+
+    it('should provide a readable `toString` representation', function () {
+      iterator.toString().should.equal('[BufferedIterator {next: a, buffer: 1}]');
+    });
+
+    describe('before reading an item', function () {
+      it('should have emitted the `readable` event', function () {
+        iterator._eventCounts.readable.should.equal(1);
+      });
+
+      it('should not have emitted the `end` event', function () {
+        iterator._eventCounts.end.should.equal(0);
+      });
+
+      it('should not have ended', function () {
+        iterator.ended.should.be.false;
+      });
+
+      it('should not have been destroyed', function () {
+        iterator.destroyed.should.be.false;
+      });
+
+      it('should not be done', function () {
+        iterator.done.should.be.false;
+      });
+
+      it('should be readable', function () {
+        iterator.readable.should.be.true;
+      });
+    });
+
+    describe('after reading the item and destroying', function () {
+      var item;
+      before(function () {
+        item = iterator.read();
+        iterator.destroy();
+      });
+
+      it('should have read the item', function () {
+        item.should.equal('a');
+      });
+
+      it('should not have emitted the `readable` event anymore', function () {
+        iterator._eventCounts.readable.should.equal(1);
+      });
+
+      it('should not have emitted the `end` event', function () {
+        iterator._eventCounts.end.should.equal(0);
+      });
+
+      it('should not have ended', function () {
+        iterator.ended.should.be.false;
+      });
+
+      it('should have been destroyed', function () {
+        iterator.destroyed.should.be.true;
+      });
+
+      it('should be done', function () {
+        iterator.done.should.be.true;
+      });
+
+      it('should not be readable', function () {
+        iterator.readable.should.be.false;
+      });
+
+      it('should return null when `read` is called', function () {
+        expect(iterator.read()).to.be.null;
+      });
+    });
+  });
+
+  describe('A BufferedIterator with an asynchronous flush that is destroyed', function () {
+    var iterator;
+    before(function () {
+      iterator = new BufferedIterator({ maxBufferSize: 1 });
+      iterator._read = function (item, done) {
+        this._push('a');
+        done();
+      };
+      iterator._flush = function (done) {
+        setImmediate(function () {
+          iterator._push('x');
+          iterator._push('y');
+          done();
+        });
+      };
+      captureEvents(iterator, 'readable', 'end');
+    });
+
+    it('should provide a readable `toString` representation', function () {
+      iterator.toString().should.equal('[BufferedIterator {next: a, buffer: 1}]');
+    });
+
+    describe('before reading an item', function () {
+      it('should have emitted the `readable` event', function () {
+        iterator._eventCounts.readable.should.equal(1);
+      });
+
+      it('should not have emitted the `end` event', function () {
+        iterator._eventCounts.end.should.equal(0);
+      });
+
+      it('should not have ended', function () {
+        iterator.ended.should.be.false;
+      });
+
+      it('should not have been destroyed', function () {
+        iterator.destroyed.should.be.false;
+      });
+
+      it('should not be done', function () {
+        iterator.done.should.be.false;
+      });
+
+      it('should be readable', function () {
+        iterator.readable.should.be.true;
+      });
+    });
+
+    describe('after reading the item and destroying', function () {
+      var item;
+      before(function () {
+        item = iterator.read();
+        iterator.destroy();
+      });
+
+      it('should have read the item', function () {
+        item.should.equal('a');
+      });
+
+      it('should not have emitted the `readable` event anymore', function () {
+        iterator._eventCounts.readable.should.equal(1);
+      });
+
+      it('should not have emitted the `end` event', function () {
+        iterator._eventCounts.end.should.equal(0);
+      });
+
+      it('should not have ended', function () {
+        iterator.ended.should.be.false;
+      });
+
+      it('should have been destroyed', function () {
+        iterator.destroyed.should.be.true;
+      });
+
+      it('should be done', function () {
+        iterator.done.should.be.true;
+      });
+
+      it('should not be readable', function () {
+        iterator.readable.should.be.false;
+      });
+
+      it('should return null when `read` is called', function () {
+        expect(iterator.read()).to.be.null;
+      });
     });
   });
 
@@ -1841,6 +2409,115 @@ describe('BufferedIterator', function () {
       it('reads the source until the end', function () {
         iterator._read.should.have.callCount(10);
       });
+    });
+  });
+
+  describe('A BufferedIterator that is destroyed', function () {
+    var iterator, i = 0;
+    before(function () {
+      iterator = new BufferedIterator();
+      iterator._read = sinon.spy(function (count, next) {
+        this._push(++i);
+        next();
+      });
+      captureEvents(iterator, 'data', 'end', 'readable');
+      iterator.destroy();
+    });
+
+    it('should not call _read()', function () {
+      iterator._read.should.have.callCount(0);
+    });
+
+    it('should emit an error when calling _push', function () {
+      (function () { iterator._push(10); }).should.throw('Cannot push after the iterator was ended.');
+    });
+
+    it('should have an empty buffer', function () {
+      iterator._buffer.length.should.equal(0);
+    });
+
+    it('should not have ended', function () {
+      iterator.ended.should.be.false;
+    });
+
+    it('should have been destroyed', function () {
+      iterator.destroyed.should.be.true;
+    });
+
+    it('should be done', function () {
+      iterator.done.should.be.true;
+    });
+
+    it('should not be readable', function () {
+      iterator.readable.should.be.false;
+    });
+
+    it('cannot be made readable again', function () {
+      iterator.readable = true;
+      iterator.readable.should.be.false;
+    });
+
+    it('should return null when trying to read', function () {
+      expect(iterator.read()).to.be.null;
+    });
+
+    it('should not have any listeners for data, readable, or end', function () {
+      expect(iterator._events).to.not.contain.key('data');
+      expect(iterator._events).to.not.contain.key('readable');
+      expect(iterator._events).to.not.contain.key('end');
+    });
+  });
+
+  describe('A BufferedIterator that is destroyed after the first item', function () {
+    var iterator, i = 0;
+    before(function () {
+      iterator = new BufferedIterator();
+      iterator._read = sinon.spy(function (count, next) {
+        this._push(++i);
+        next();
+        if (i === 1)
+          iterator.destroy();
+      });
+      captureEvents(iterator, 'data', 'end', 'readable');
+    });
+
+    it('should have called _read() once', function () {
+      iterator._read.should.have.callCount(1);
+    });
+
+    it('should have an empty buffer', function () {
+      iterator._buffer.length.should.equal(0);
+    });
+
+    it('should not have ended', function () {
+      iterator.ended.should.be.false;
+    });
+
+    it('should have been destroyed', function () {
+      iterator.destroyed.should.be.true;
+    });
+
+    it('should be done', function () {
+      iterator.done.should.be.true;
+    });
+
+    it('should not be readable', function () {
+      iterator.readable.should.be.false;
+    });
+
+    it('cannot be made readable again', function () {
+      iterator.readable = true;
+      iterator.readable.should.be.false;
+    });
+
+    it('should return null when trying to read', function () {
+      expect(iterator.read()).to.be.null;
+    });
+
+    it('should not have any listeners for data, readable, or end', function () {
+      expect(iterator._events).to.not.contain.key('data');
+      expect(iterator._events).to.not.contain.key('readable');
+      expect(iterator._events).to.not.contain.key('end');
     });
   });
 });

--- a/test/BufferedIterator-test.js
+++ b/test/BufferedIterator-test.js
@@ -108,9 +108,9 @@ describe('BufferedIterator', function () {
         iterator.readable.should.be.false;
       });
 
-      it('should not allow pushing', function () {
-        (function () { iterator._push(1); })
-          .should.throw('Cannot push after the iterator was ended.');
+      it('should allow pushing but have no effect', function () {
+        iterator._push(1);
+        iterator.toString().should.equal('[BufferedIterator {buffer: 0}]');
       });
     });
   });
@@ -2428,8 +2428,9 @@ describe('BufferedIterator', function () {
       iterator._read.should.have.callCount(0);
     });
 
-    it('should emit an error when calling _push', function () {
-      (function () { iterator._push(10); }).should.throw('Cannot push after the iterator was ended.');
+    it('should allow pushing but have no effect', function () {
+      iterator._push(10);
+      iterator.toString().should.equal('[BufferedIterator {buffer: 0}]');
     });
 
     it('should have an empty buffer', function () {


### PR DESCRIPTION
As discussed in #6, this adds a `destroy` function that is compatible with Node's ReadableStream API.

This introduces a new `DESTROYED`, a `destroyed` getter and a `done` (destroyed or ended).

Breaking change:
* Calling `_push` after being ended will not throw an error anymore.

(This does not yet include automatically destroying transformed sources when done, this will be added in a separate PR)

Be sure to double-check the unit tests, they *should* cover all cases.