### PR TITLE
Fix ClonedIterator not respecting sources without autoStart, Closes #26

### DIFF
--- a/asynciterator.ts
+++ b/asynciterator.ts
@@ -608,13 +608,11 @@ export class ArrayIterator<T> extends AsyncIterator<T> {
     super();
     const buffer = items ? [...items] : [];
     this._sourceStarted = autoStart !== false;
-    if (this._sourceStarted && buffer.length === 0) {
+    if (this._sourceStarted && buffer.length === 0)
       this.close();
-    }
-    else {
-      this.readable = true;
+    else
       this._buffer = buffer;
-    }
+    this.readable = true;
   }
 
   /* Reads an item from the iterator. */
@@ -1604,7 +1602,8 @@ export class ClonedIterator<T> extends TransformIterator<T> {
       // Subscribe to history events
       history.register(this);
       // If there are already items in history, this clone is readable
-      if ((source as any)._sourceStarted !== false && history.readAt(0) !== null)
+      // If the source has a lazy start, always mark this iterator as readable without eagerly triggering a read.
+      if ((source as any)._sourceStarted === false || history.readAt(0) !== null)
         this.readable = true;
     }
 
@@ -1731,7 +1730,8 @@ class HistoryReader<T> {
       const end = () => {
         // Close the clone if all items had been emitted
         for (const clone of this._clones as ClonedIterator<T>[]) {
-          if ((clone as any)._readPosition === this._history.length)
+          if ((clone as any)._sourceStarted !== false &&
+            (clone as any)._readPosition === this._history.length)
             clone.close();
         }
         this._clones = null;

--- a/test/integration-test.js
+++ b/test/integration-test.js
@@ -24,109 +24,191 @@ describe('Integration tests', () => {
     });
   });
 
-  describe('A clone of an empty ArrayIterator without autoStart', () => {
-    let arrayIterator, clonedIterator;
+  describe('Cloning iterators', () => {
+    describe('A clone of an empty ArrayIterator without autoStart', () => {
+      let arrayIterator, clonedIterator;
 
-    before(() => {
-      arrayIterator = new ArrayIterator([], { autoStart: false });
-      clonedIterator = arrayIterator.clone();
+      before(() => {
+        arrayIterator = new ArrayIterator([], { autoStart: false });
+        clonedIterator = arrayIterator.clone();
+      });
+
+      it('emits an end event after attaching a data listener', done => {
+        clonedIterator.on('data', () => { /* drain */ });
+        clonedIterator.on('end', done);
+      });
     });
 
-    it('emits an end event after attaching a data listener', done => {
-      clonedIterator.on('data', () => { /* drain */ });
-      clonedIterator.on('end', done);
-    });
-  });
+    describe('An async clone of an empty ArrayIterator without autoStart', () => {
+      let arrayIterator, clonedIterator;
 
-  describe('A double clone of an empty ArrayIterator without autoStart', () => {
-    let arrayIterator, clonedIterator;
+      before(async () => {
+        arrayIterator = new ArrayIterator([], { autoStart: false });
 
-    before(() => {
-      arrayIterator = new ArrayIterator([], { autoStart: false });
-      clonedIterator = arrayIterator.clone().clone();
-    });
+        // Wait a tick
+        await new Promise(resolve => setImmediate(resolve));
 
-    it('emits an end event after attaching a data listener', done => {
-      clonedIterator.on('data', () => { /* drain */ });
-      clonedIterator.on('end', done);
-    });
-  });
+        clonedIterator = arrayIterator.clone();
+      });
 
-  describe('A clone of a sequence of an empty ArrayIterator, and TransformIterator without autoStart', () => {
-    let arrayIterator, transformIterator, clonedIterator;
-
-    before(() => {
-      arrayIterator = new ArrayIterator([], { autoStart: false });
-      transformIterator = new TransformIterator(arrayIterator, { autoStart: false });
-      clonedIterator = transformIterator.clone();
+      it('emits an end event after attaching a data listener', done => {
+        clonedIterator.on('data', () => { /* drain */ });
+        clonedIterator.on('end', done);
+      });
     });
 
-    it('emits an end event after attaching a data listener', done => {
-      clonedIterator.on('data', () => { /* drain */ });
-      clonedIterator.on('end', done);
-    });
-  });
+    describe('A multi-clone of an empty ArrayIterator without autoStart', () => {
+      let arrayIterator, clonedIterator1, clonedIterator2;
 
-  describe('A clone of a sequence of an empty ArrayIterator, TransformIterator, and Unioniterator without autoStart', () => {
-    let arrayIterator, transformIterator, unionIterator, clonedIterator;
+      before(() => {
+        arrayIterator = new ArrayIterator([], { autoStart: false });
+        clonedIterator1 = arrayIterator.clone();
+        clonedIterator2 = arrayIterator.clone();
+      });
 
-    before(() => {
-      arrayIterator = new ArrayIterator([], { autoStart: false });
-      transformIterator = new TransformIterator(arrayIterator, { autoStart: false });
-      unionIterator = new UnionIterator([transformIterator], { autoStart: false });
-      clonedIterator = unionIterator.clone();
-    });
+      it('emits an end event on clone 1 after attaching a data listener', done => {
+        clonedIterator1.on('data', () => { /* drain */ });
+        clonedIterator1.on('end', done);
+      });
 
-    it('emits an end event after attaching a data listener', done => {
-      clonedIterator.on('data', () => { /* drain */ });
-      clonedIterator.on('end', done);
-    });
-  });
-
-  describe('A clone of an ArrayIterator without autoStart', () => {
-    let arrayIterator, clonedIterator;
-
-    before(() => {
-      arrayIterator = new ArrayIterator([1, 2, 3], { autoStart: false });
-      clonedIterator = arrayIterator.clone();
+      it('emits an end event on clone 2 after attaching a data listener', done => {
+        clonedIterator2.on('data', () => { /* drain */ });
+        clonedIterator2.on('end', done);
+      });
     });
 
-    it('emits an end event after attaching a data listener', done => {
-      clonedIterator.on('data', () => { /* drain */ });
-      clonedIterator.on('end', done);
-    });
-  });
+    describe('An async multi-clone of an empty ArrayIterator without autoStart', () => {
+      let arrayIterator, clonedIterator1, clonedIterator2;
 
-  describe('A double clone of an ArrayIterator without autoStart', () => {
-    let arrayIterator, clonedIterator;
+      before(async () => {
+        arrayIterator = new ArrayIterator([], { autoStart: false });
 
-    before(() => {
-      arrayIterator = new ArrayIterator([1, 2, 3], { autoStart: false });
-      clonedIterator = arrayIterator.clone().clone();
-    });
+        // Wait a tick
+        await new Promise(resolve => setImmediate(resolve));
 
-    it('emits an end event after attaching a data listener', done => {
-      clonedIterator.on('data', () => { /* drain */ });
-      clonedIterator.on('end', done);
-    });
-  });
+        clonedIterator1 = arrayIterator.clone();
+        clonedIterator2 = arrayIterator.clone();
+      });
 
-  describe('A double async clone of an ArrayIterator without autoStart', () => {
-    let arrayIterator, clonedIterator;
+      it('emits an end event on clone 1 after attaching a data listener', done => {
+        clonedIterator1.on('data', () => { /* drain */ });
+        clonedIterator1.on('end', done);
+      });
 
-    before(async () => {
-      arrayIterator = new ArrayIterator([1, 2, 3], { autoStart: false });
-      clonedIterator = arrayIterator.clone();
-
-      // Wait a tick
-      await new Promise(resolve => setImmediate(resolve));
-
-      clonedIterator = clonedIterator.clone();
+      it('emits an end event on clone 2 after attaching a data listener', done => {
+        clonedIterator2.on('data', () => { /* drain */ });
+        clonedIterator2.on('end', done);
+      });
     });
 
-    it('emits an end event after attaching a data listener', done => {
-      clonedIterator.on('data', () => { /* drain */ });
-      clonedIterator.on('end', done);
+    describe('A double clone of an empty ArrayIterator without autoStart', () => {
+      let arrayIterator, clonedIterator;
+
+      before(() => {
+        arrayIterator = new ArrayIterator([], { autoStart: false });
+        clonedIterator = arrayIterator.clone().clone();
+      });
+
+      it('emits an end event after attaching a data listener', done => {
+        clonedIterator.on('data', () => { /* drain */ });
+        clonedIterator.on('end', done);
+      });
+    });
+
+    describe('A clone of a sequence of an empty ArrayIterator, and TransformIterator without autoStart', () => {
+      let arrayIterator, transformIterator, clonedIterator;
+
+      before(() => {
+        arrayIterator = new ArrayIterator([], { autoStart: false });
+        transformIterator = new TransformIterator(arrayIterator, { autoStart: false });
+        clonedIterator = transformIterator.clone();
+      });
+
+      it('emits an end event after attaching a data listener', done => {
+        clonedIterator.on('data', () => { /* drain */ });
+        clonedIterator.on('end', done);
+      });
+    });
+
+    describe('A clone of a sequence of an empty ArrayIterator, TransformIterator, and Unioniterator without autoStart', () => {
+      let arrayIterator, transformIterator, unionIterator, clonedIterator;
+
+      before(() => {
+        arrayIterator = new ArrayIterator([], { autoStart: false });
+        transformIterator = new TransformIterator(arrayIterator, { autoStart: false });
+        unionIterator = new UnionIterator([transformIterator], { autoStart: false });
+        clonedIterator = unionIterator.clone();
+      });
+
+      it('emits an end event after attaching a data listener', done => {
+        clonedIterator.on('data', () => { /* drain */ });
+        clonedIterator.on('end', done);
+      });
+    });
+
+    describe('A clone of an ArrayIterator without autoStart', () => {
+      let arrayIterator, clonedIterator;
+
+      before(() => {
+        arrayIterator = new ArrayIterator([1, 2, 3], { autoStart: false });
+        clonedIterator = arrayIterator.clone();
+      });
+
+      it('emits an end event after attaching a data listener', done => {
+        clonedIterator.on('data', () => { /* drain */ });
+        clonedIterator.on('end', done);
+      });
+    });
+
+    describe('An async clone of an ArrayIterator without autoStart', () => {
+      let arrayIterator, clonedIterator;
+
+      before(async () => {
+        arrayIterator = new ArrayIterator([1, 2, 3], { autoStart: false });
+
+        // Wait a tick
+        await new Promise(resolve => setImmediate(resolve));
+
+        clonedIterator = arrayIterator.clone();
+      });
+
+      it('emits an end event after attaching a data listener', done => {
+        clonedIterator.on('data', () => { /* drain */ });
+        clonedIterator.on('end', done);
+      });
+    });
+
+    describe('A double clone of an ArrayIterator without autoStart', () => {
+      let arrayIterator, clonedIterator;
+
+      before(() => {
+        arrayIterator = new ArrayIterator([1, 2, 3], { autoStart: false });
+        clonedIterator = arrayIterator.clone().clone();
+      });
+
+      it('emits an end event after attaching a data listener', done => {
+        clonedIterator.on('data', () => { /* drain */ });
+        clonedIterator.on('end', done);
+      });
+    });
+
+    describe('A double async clone of an ArrayIterator without autoStart', () => {
+      let arrayIterator, clonedIterator;
+
+      before(async () => {
+        arrayIterator = new ArrayIterator([1, 2, 3], { autoStart: false });
+        clonedIterator = arrayIterator.clone();
+
+        // Wait a tick
+        await new Promise(resolve => setImmediate(resolve));
+
+        clonedIterator = clonedIterator.clone();
+      });
+
+      it('emits an end event after attaching a data listener', done => {
+        clonedIterator.on('data', () => { /* drain */ });
+        clonedIterator.on('end', done);
+      });
     });
   });
 });

--- a/test/integration-test.js
+++ b/test/integration-test.js
@@ -23,4 +23,110 @@ describe('Integration tests', () => {
       unionIterator.on('end', done);
     });
   });
+
+  describe('A clone of an empty ArrayIterator without autoStart', () => {
+    let arrayIterator, clonedIterator;
+
+    before(() => {
+      arrayIterator = new ArrayIterator([], { autoStart: false });
+      clonedIterator = arrayIterator.clone();
+    });
+
+    it('emits an end event after attaching a data listener', done => {
+      clonedIterator.on('data', () => { /* drain */ });
+      clonedIterator.on('end', done);
+    });
+  });
+
+  describe('A double clone of an empty ArrayIterator without autoStart', () => {
+    let arrayIterator, clonedIterator;
+
+    before(() => {
+      arrayIterator = new ArrayIterator([], { autoStart: false });
+      clonedIterator = arrayIterator.clone().clone();
+    });
+
+    it('emits an end event after attaching a data listener', done => {
+      clonedIterator.on('data', () => { /* drain */ });
+      clonedIterator.on('end', done);
+    });
+  });
+
+  describe('A clone of a sequence of an empty ArrayIterator, and TransformIterator without autoStart', () => {
+    let arrayIterator, transformIterator, clonedIterator;
+
+    before(() => {
+      arrayIterator = new ArrayIterator([], { autoStart: false });
+      transformIterator = new TransformIterator(arrayIterator, { autoStart: false });
+      clonedIterator = transformIterator.clone();
+    });
+
+    it('emits an end event after attaching a data listener', done => {
+      clonedIterator.on('data', () => { /* drain */ });
+      clonedIterator.on('end', done);
+    });
+  });
+
+  describe('A clone of a sequence of an empty ArrayIterator, TransformIterator, and Unioniterator without autoStart', () => {
+    let arrayIterator, transformIterator, unionIterator, clonedIterator;
+
+    before(() => {
+      arrayIterator = new ArrayIterator([], { autoStart: false });
+      transformIterator = new TransformIterator(arrayIterator, { autoStart: false });
+      unionIterator = new UnionIterator([transformIterator], { autoStart: false });
+      clonedIterator = unionIterator.clone();
+    });
+
+    it('emits an end event after attaching a data listener', done => {
+      clonedIterator.on('data', () => { /* drain */ });
+      clonedIterator.on('end', done);
+    });
+  });
+
+  describe('A clone of an ArrayIterator without autoStart', () => {
+    let arrayIterator, clonedIterator;
+
+    before(() => {
+      arrayIterator = new ArrayIterator([1, 2, 3], { autoStart: false });
+      clonedIterator = arrayIterator.clone();
+    });
+
+    it('emits an end event after attaching a data listener', done => {
+      clonedIterator.on('data', () => { /* drain */ });
+      clonedIterator.on('end', done);
+    });
+  });
+
+  describe('A double clone of an ArrayIterator without autoStart', () => {
+    let arrayIterator, clonedIterator;
+
+    before(() => {
+      arrayIterator = new ArrayIterator([1, 2, 3], { autoStart: false });
+      clonedIterator = arrayIterator.clone().clone();
+    });
+
+    it('emits an end event after attaching a data listener', done => {
+      clonedIterator.on('data', () => { /* drain */ });
+      clonedIterator.on('end', done);
+    });
+  });
+
+  describe('A double async clone of an ArrayIterator without autoStart', () => {
+    let arrayIterator, clonedIterator;
+
+    before(async () => {
+      arrayIterator = new ArrayIterator([1, 2, 3], { autoStart: false });
+      clonedIterator = arrayIterator.clone();
+
+      // Wait a tick
+      await new Promise(resolve => setImmediate(resolve));
+
+      clonedIterator = clonedIterator.clone();
+    });
+
+    it('emits an end event after attaching a data listener', done => {
+      clonedIterator.on('data', () => { /* drain */ });
+      clonedIterator.on('end', done);
+    });
+  });
 });


### PR DESCRIPTION
This PR does the following:

* `ClonedIterator` does not eagerly pull the history if `source._sourceStarted` is `false`.
* The `_sourceStarted` flag is also added to `ArrayIterator`.
* The `_sourceStarted` flag is moved from `TransformIterator` to `BufferedIterator`, so that it also applies to the `UnionIterator`.

**Warning: this PR fixes the original problem, but I found a new edge-case that is not working yet.**
A (failing) integration test is included for this case.
I've spent quite a bit of time trying to find the problem, but the chained clones and history were breaking my head.
I hope to look into this later with a fresh mind, but if you have any thoughts/suggestions on where I could debug next, please let me know.

-----

I was wondering if it makes sense to move `_sourceStarted` up all the way to the base `AsyncIterator` class. But such a change may be too invasive, and may perhaps be done in a separate PR.