### PR TITLE
Manually export package.json to support introspective tools

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,11 @@
   "type": "module",
   "main": "dist/asynciterator.cjs",
   "exports": {
-    "import": "./dist/asynciterator.js",
-    "require": "./dist/asynciterator.cjs"
+    "./package.json": "./package.json",
+    ".": {
+      "import": "./dist/asynciterator.js",
+      "require": "./dist/asynciterator.cjs"
+    }
   },
   "module": "./dist/asynciterator.js",
   "types": "./dist/asynciterator.d.ts",


### PR DESCRIPTION
Tools such as Components.js and react-native require introspection of
the package.json file. Since the new export syntax does not imply
package.json resolution yet (nodejs/node#33460), this has to be exported
explicitly. Ideally, this would be something that is done implicitly by
Node.js, but this is something that is still being discussed at
nodejs/node#33460. So until then, this has to be added explictly to
avoid breaking other tooling.

Related to uuidjs/uuid#444