### PR TITLE
Refactors ArrayIterator to use an internal index instead of Array#shift()

### DIFF
--- a/asynciterator.ts
+++ b/asynciterator.ts
@@ -631,16 +631,18 @@ export class ArrayIterator<T> extends AsyncIterator<T> {
   private _buffer?: T[];
   protected _currentIndex: number;
   protected _sourceStarted: boolean;
+  protected _splicingThreshold: number;
 
   /**
     Creates a new `ArrayIterator`.
     @param {Array} items The items that will be emitted.
   */
-  constructor(items?: Iterable<T>, { autoStart = true } = {}) {
+  constructor(items?: Iterable<T>, { autoStart = true, splicingThreshold = 64 } = {}) {
     super();
     const buffer = items ? [...items] : [];
     this._sourceStarted = autoStart !== false;
     this._currentIndex = 0;
+    this._splicingThreshold = splicingThreshold;
     if (this._sourceStarted && buffer.length === 0)
       this.close();
     else
@@ -663,8 +665,8 @@ export class ArrayIterator<T> extends AsyncIterator<T> {
         delete this._buffer;
         this.close();
       }
-      else if (this._currentIndex === 64) {
-        this._buffer.splice(0, 64);
+      else if (this._currentIndex === this._splicingThreshold) {
+        this._buffer.splice(0, this._splicingThreshold);
         this._currentIndex = 0;
       }
     }

--- a/asynciterator.ts
+++ b/asynciterator.ts
@@ -629,6 +629,7 @@ export class SingletonIterator<T> extends AsyncIterator<T> {
 */
 export class ArrayIterator<T> extends AsyncIterator<T> {
   private _buffer?: T[];
+  protected _currentIndex: number;
   protected _sourceStarted: boolean;
 
   /**
@@ -639,6 +640,7 @@ export class ArrayIterator<T> extends AsyncIterator<T> {
     super();
     const buffer = items ? [...items] : [];
     this._sourceStarted = autoStart !== false;
+    this._currentIndex = 0;
     if (this._sourceStarted && buffer.length === 0)
       this.close();
     else
@@ -652,21 +654,24 @@ export class ArrayIterator<T> extends AsyncIterator<T> {
       this._sourceStarted = true;
 
     let item = null;
-    const buffer = this._buffer;
-    if (buffer) {
-      if (buffer.length !== 0)
-        item = buffer.shift() as T;
-      if (buffer.length === 0) {
+    let { _currentIndex, _buffer } = this;
+    if (_buffer) {
+      if (_currentIndex < _buffer.length) {
+        item = _buffer[_currentIndex];
+        _currentIndex += 1;
+      }
+      if (_currentIndex === _buffer.length) {
         delete this._buffer;
         this.close();
       }
+      this._currentIndex = _currentIndex;
     }
     return item;
   }
 
   /* Generates details for a textual representation of the iterator. */
   protected _toStringDetails() {
-    return `(${this._buffer && this._buffer.length || 0})`;
+    return `(${this._buffer ? this._buffer.length - this._currentIndex : 0})`;
   }
 
   /* Called by {@link module:asynciterator.AsyncIterator#destroy} */

--- a/asynciterator.ts
+++ b/asynciterator.ts
@@ -654,17 +654,15 @@ export class ArrayIterator<T> extends AsyncIterator<T> {
       this._sourceStarted = true;
 
     let item = null;
-    let { _currentIndex, _buffer } = this;
-    if (_buffer) {
-      if (_currentIndex < _buffer.length) {
-        item = _buffer[_currentIndex];
-        _currentIndex += 1;
+    if (this._buffer) {
+      if (this._currentIndex < this._buffer.length) {
+        item = this._buffer[this._currentIndex];
+        this._currentIndex += 1;
       }
-      if (_currentIndex === _buffer.length) {
+      if (this._currentIndex === this._buffer.length) {
         delete this._buffer;
         this.close();
       }
-      this._currentIndex = _currentIndex;
     }
     return item;
   }

--- a/asynciterator.ts
+++ b/asynciterator.ts
@@ -663,6 +663,10 @@ export class ArrayIterator<T> extends AsyncIterator<T> {
         delete this._buffer;
         this.close();
       }
+      else if (this._currentIndex === 64) {
+        this._buffer.splice(0, 64);
+        this._currentIndex = 0;
+      }
     }
     return item;
   }

--- a/asynciterator.ts
+++ b/asynciterator.ts
@@ -683,6 +683,24 @@ export class ArrayIterator<T> extends AsyncIterator<T> {
     delete this._buffer;
     callback();
   }
+
+  /**
+   Consume all remaining items of the iterator into an array that will be returned asynchronously.
+   @param {object} [options] Settings for array creation
+   @param {integer} [options.limit] The maximum number of items to place in the array.
+   */
+  async toArray(options: { limit?: number } = {}): Promise<T[]> {
+    const { _buffer: buffer, _currentIndex: currentIndex } = this;
+    if (buffer) {
+      const endIndex = typeof options.limit === 'number' ? currentIndex + options.limit : buffer.length;
+      const items = buffer.slice(this._currentIndex, endIndex);
+      this._currentIndex = endIndex;
+      if (endIndex >= buffer.length)
+        this.close();
+      return items;
+    }
+    return [];
+  }
 }
 
 

--- a/test/ArrayIterator-test.js
+++ b/test/ArrayIterator-test.js
@@ -679,4 +679,17 @@ describe('ArrayIterator', () => {
       });
     });
   });
+
+  describe('An ArrayIterator with 135 items', () => {
+    it('should splice its buffer every 64 items to free up  memory', () => {
+      const array = new Array(135).fill(true);
+      const iterator = new ArrayIterator(array);
+      for (let i = 0; i < 64; i += 1)
+        iterator.read();
+      iterator._buffer.length.should.equal(71);
+      for (let i = 0; i < 64; i += 1)
+        iterator.read();
+      iterator._buffer.length.should.equal(7);
+    });
+  });
 });

--- a/test/ArrayIterator-test.js
+++ b/test/ArrayIterator-test.js
@@ -702,4 +702,67 @@ describe('ArrayIterator', () => {
       iterator._buffer.length.should.equal(35);
     });
   });
+
+  describe('An Infinity splicing threshold', () => {
+    it('should lead the iterator to never splice its buffer', () => {
+      const array = new Array(135).fill(true);
+      const iterator = new ArrayIterator(array, { splicingThreshold: Infinity });
+      for (let i = 0; i < 100; i += 1)
+        iterator.read();
+      iterator._buffer.length.should.equal(135);
+    });
+  });
+
+  describe('The toArray() method', () => {
+    it('should return an empty array given an empty source array', async () => {
+      const array = [];
+      const iterator = new ArrayIterator(array);
+      const items = await iterator.toArray();
+      items.length.should.equal(0);
+    });
+
+    it('should return an empty array given an empty source array, even with the limit option', async () => {
+      const array = [];
+      const iterator = new ArrayIterator(array);
+      const items = await iterator.toArray({ limit: 10 });
+      items.length.should.equal(0);
+    });
+
+    it('should return a copy of the entire source array if called before any other read operation', async () => {
+      const array = [0, 1, 2, 3, 4, 5, 6];
+      const iterator = new ArrayIterator(array);
+      const items = await iterator.toArray();
+      items.should.not.equal(array);
+      for (let i = 0; i < array.length; i += 1)
+        items[i].should.equal(array[i]);
+    });
+
+    it('should return a copy of the entire source array if called before any other read operation with a limit greater than the length of the source array', async () => {
+      const array = [0, 1, 2, 3, 4, 5, 6];
+      const iterator = new ArrayIterator(array);
+      const items = await iterator.toArray({ limit: 10 });
+      items.should.not.equal(array);
+      for (let i = 0; i < array.length; i += 1)
+        items[i].should.equal(array[i]);
+    });
+
+    it('should return a portion of the source array if called with the limit option', async () => {
+      const array = [0, 1, 2, 3, 4, 5, 6];
+      const iterator = new ArrayIterator(array);
+      const items = await iterator.toArray({ limit: 2 });
+      items.should.not.equal(array);
+      for (let i = 0; i < 2; i += 1)
+        items[i].should.equal(array[i]);
+    });
+
+    it('should return a portion of the source array if called with the limit option after a read operation', async () => {
+      const array = [0, 1, 2, 3, 4, 5, 6];
+      const iterator = new ArrayIterator(array);
+      iterator.read();
+      const items = await iterator.toArray({ limit: 2 });
+      items.should.not.equal(array);
+      for (let i = 0; i < 2; i += 1)
+        items[i].should.equal(array[i + 1]);
+    });
+  });
 });

--- a/test/ArrayIterator-test.js
+++ b/test/ArrayIterator-test.js
@@ -680,8 +680,8 @@ describe('ArrayIterator', () => {
     });
   });
 
-  describe('An ArrayIterator with 135 items', () => {
-    it('should splice its buffer every 64 items to free up  memory', () => {
+  describe('The default splicing threshold', () => {
+    it('should lead the iterator to splice its buffer every 64 items', () => {
       const array = new Array(135).fill(true);
       const iterator = new ArrayIterator(array);
       for (let i = 0; i < 64; i += 1)
@@ -690,6 +690,16 @@ describe('ArrayIterator', () => {
       for (let i = 0; i < 64; i += 1)
         iterator.read();
       iterator._buffer.length.should.equal(7);
+    });
+  });
+
+  describe('A custom splicing threshold', () => {
+    it('should lead the iterator to splice its buffer accordingly', () => {
+      const array = new Array(135).fill(true);
+      const iterator = new ArrayIterator(array, { splicingThreshold: 100 });
+      for (let i = 0; i < 100; i += 1)
+        iterator.read();
+      iterator._buffer.length.should.equal(35);
     });
   });
 });


### PR DESCRIPTION
As measured on Node 16.x running on a 13'' 2020 MacBook Pro (Apple Silicon, M1, 16 GB RAM), it takes ~3000ms for the current implementation of ArrayIterator to run through a 200k items array.

Research for #38 and #44 pointed at `Array#shift()` being a potential bottleneck, thus this refactored version that uses an internal index instead of modifying the array. With this version, the same test terminates in ~8ms. The difference is so big to be almost unbelievable but I've managed to reproduce it multiple times. The following should suffice:

```typescript
let i = 0;
const arr = new Array(200000).fill(true).map(() => i++);
const now = Date.now();
new ArrayIterator(arr).on('data', () => {}).on('end', () => {
  console.log('elapsed', Date.now() - now);
});
```