### PR TITLE
Simpler and faster filtering, mapping, skipping and limiting

### DIFF
--- a/asynciterator.ts
+++ b/asynciterator.ts
@@ -1281,9 +1281,7 @@ export class SynchronousTransformIterator<S, D = S> extends AsyncIterator<D> {
       this.close();
     };
     const onSourceError = (err: Error) => {
-      scheduleTask(() => {
-        this.emit('error', err);
-      });
+      this.emit('error', err);
     };
     const onSourceReadable = () => {
       if (this.readable) {
@@ -1293,9 +1291,7 @@ export class SynchronousTransformIterator<S, D = S> extends AsyncIterator<D> {
         //       It looks like the debouncing that happens in `set readable()`
         //       in `AsyncIterator` prevents the event from firing as `this`
         //       is already readable.
-        scheduleTask(() => {
-          this.emit('readable');
-        });
+        this.emit('readable');
       }
       else {
         this.readable = true;

--- a/asynciterator.ts
+++ b/asynciterator.ts
@@ -456,7 +456,6 @@ export class AsyncIterator<T> extends EventEmitter {
     @returns {module:asynciterator.AsyncIterator} A new iterator that maps the items from this iterator
   */
   map<D>(map: (item: T) => D, self?: any): AsyncIterator<D> {
-    // return this.transform({ map: self ? map.bind(self) : map });
     return new MappingIterator(this, self ? map.bind(self) : map);
   }
 
@@ -471,7 +470,6 @@ export class AsyncIterator<T> extends EventEmitter {
   filter(filter: (item: T) => boolean, self?: any): AsyncIterator<T>;
   filter(filter: (item: T) => boolean, self?: any): AsyncIterator<T> {
     return new FilteringIterator(this, self ? filter.bind(self) : filter);
-    // return this.transform({ filter: self ? filter.bind(self) : filter });
   }
 
   /**
@@ -512,7 +510,6 @@ export class AsyncIterator<T> extends EventEmitter {
     @returns {module:asynciterator.AsyncIterator} A new iterator that skips the given number of items
   */
   skip(offset: number): AsyncIterator<T> {
-    // return this.transform({ offset });
     return new SkippingIterator(this, offset);
   }
 
@@ -523,7 +520,6 @@ export class AsyncIterator<T> extends EventEmitter {
     @returns {module:asynciterator.AsyncIterator} A new iterator with at most the given number of items
   */
   take(limit: number): AsyncIterator<T> {
-    // return this.transform({ limit });
     return new LimitingIterator(this, limit);
   }
 

--- a/asynciterator.ts
+++ b/asynciterator.ts
@@ -1322,7 +1322,7 @@ export class LimitingIterator<T> extends AsyncIterator<T> {
     let item: T | null;
     let count = 0;
     this.read = (): T | null => {
-      while ((item = source.read()) !== null) {
+      if ((item = source.read()) !== null) {
         if (count < limit) {
           count += 1;
           return item;

--- a/test/SimpleTransformIterator-test.js
+++ b/test/SimpleTransformIterator-test.js
@@ -9,6 +9,8 @@ import {
   scheduleTask,
   MappingIterator,
   FilteringIterator,
+  SkippingIterator,
+  LimitingIterator,
 } from '../dist/asynciterator.js';
 
 import { EventEmitter } from 'events';
@@ -1349,7 +1351,7 @@ describe('SimpleTransformIterator', () => {
         });
 
         it('should be a SimpleTransformIterator', () => {
-          result.should.be.an.instanceof(SimpleTransformIterator);
+          result.should.be.an.instanceof(SkippingIterator);
         });
 
         it('should skip the given number of items', () => {
@@ -1379,7 +1381,7 @@ describe('SimpleTransformIterator', () => {
         });
 
         it('should be a SimpleTransformIterator', () => {
-          result.should.be.an.instanceof(SimpleTransformIterator);
+          result.should.be.an.instanceof(LimitingIterator);
         });
 
         it('should take the given number of items', () => {

--- a/test/SimpleTransformIterator-test.js
+++ b/test/SimpleTransformIterator-test.js
@@ -7,6 +7,8 @@ import {
   ArrayIterator,
   IntegerIterator,
   scheduleTask,
+  MappingIterator,
+  FilteringIterator,
 } from '../dist/asynciterator.js';
 
 import { EventEmitter } from 'events';
@@ -1110,8 +1112,8 @@ describe('SimpleTransformIterator', () => {
           result.on('end', done);
         });
 
-        it('should be a SimpleTransformIterator', () => {
-          result.should.be.an.instanceof(SimpleTransformIterator);
+        it('should be a MappingIterator', () => {
+          result.should.be.an.instanceof(MappingIterator);
         });
 
         it('should execute the map function on all items in order', () => {
@@ -1146,7 +1148,7 @@ describe('SimpleTransformIterator', () => {
         });
 
         it('should be a SimpleTransformIterator', () => {
-          result.should.be.an.instanceof(SimpleTransformIterator);
+          result.should.be.an.instanceof(MappingIterator);
         });
 
         it('should execute the map function on all items in order', () => {
@@ -1185,7 +1187,7 @@ describe('SimpleTransformIterator', () => {
         });
 
         it('should be a SimpleTransformIterator', () => {
-          result.should.be.an.instanceof(SimpleTransformIterator);
+          result.should.be.an.instanceof(FilteringIterator);
         });
 
         it('should execute the filter function on all items in order', () => {
@@ -1219,7 +1221,7 @@ describe('SimpleTransformIterator', () => {
         });
 
         it('should be a SimpleTransformIterator', () => {
-          result.should.be.an.instanceof(SimpleTransformIterator);
+          result.should.be.an.instanceof(FilteringIterator);
         });
 
         it('should execute the filter function on all items in order', () => {


### PR DESCRIPTION
While researching #44 , @jeswr discovered that the performance of `.map()` and `.filter()` could be greatly improved by adding simple dedicated iterators for mapping and filtering, respectively. The impact of using these simplified iterators grows with the length of the chain of iterators.

As measured on a 13'' 2020 MacBook Pro (Apple Silicon, M1, 16 GB RAM), this PR makes the following test run in ~30ms. Before this PR the same test would terminate after ~300ms - a 10x difference.

```typescript
let i = 0;
const arr = new Array(200000).fill(true).map(() => i++);

class RangeIterator<O> extends AsyncIterator<O> {
  constructor(source: O[]) {
    super();
    let i = 0;
    let l = source.length;
    this.read = (): O | null => {
      if (i >= l) {
        this.close();
        return null;
      }
      return source[i++];
    };
    Promise.resolve().then(() => {
      this.emit('readable');
    });
  }
}

const iterator = new RangeIterator(arr)
  .map((item: number) => item)
  .map((item: number) => item)
  .map((item: number) => item)
  .map((item: number) => item)
  .map((item: number) => item)
  .map((item: number) => item)
  .map((item: number) => item)
  .map((item: number) => item)
  .map((item: number) => item)
  .map((item: number) => item);

const now = Date.now();
iterator.on('data', () => {}).on('end', () => {
  console.log('elapsed', Date.now() - now);
});
```

Note that the `RangeIterator` class is just a stopgap for #47 .