### PR TITLE
Faster filtering mapping

### DIFF
--- a/asynciterator.ts
+++ b/asynciterator.ts
@@ -456,7 +456,6 @@ export class AsyncIterator<T> extends EventEmitter {
     @returns {module:asynciterator.AsyncIterator} A new iterator that maps the items from this iterator
   */
   map<D>(map: (item: T) => D, self?: any): AsyncIterator<D> {
-    // return this.transform({ map: self ? map.bind(self) : map });
     return new MappingIterator(this, self ? map.bind(self) : map);
   }
 
@@ -471,7 +470,6 @@ export class AsyncIterator<T> extends EventEmitter {
   filter(filter: (item: T) => boolean, self?: any): AsyncIterator<T>;
   filter(filter: (item: T) => boolean, self?: any): AsyncIterator<T> {
     return new FilteringIterator(this, self ? filter.bind(self) : filter);
-    // return this.transform({ filter: self ? filter.bind(self) : filter });
   }
 
   /**
@@ -512,7 +510,6 @@ export class AsyncIterator<T> extends EventEmitter {
     @returns {module:asynciterator.AsyncIterator} A new iterator that skips the given number of items
   */
   skip(offset: number): AsyncIterator<T> {
-    // return this.transform({ offset });
     return new SkippingIterator(this, offset);
   }
 
@@ -523,7 +520,6 @@ export class AsyncIterator<T> extends EventEmitter {
     @returns {module:asynciterator.AsyncIterator} A new iterator with at most the given number of items
   */
   take(limit: number): AsyncIterator<T> {
-    // return this.transform({ limit });
     return new LimitingIterator(this, limit);
   }
 

--- a/asynciterator.ts
+++ b/asynciterator.ts
@@ -1322,7 +1322,7 @@ export class LimitingIterator<T> extends AsyncIterator<T> {
     let item: T | null;
     let count = 0;
     this.read = (): T | null => {
-      while ((item = source.read()) !== null) {
+      if ((item = source.read()) !== null) {
         if (count < limit) {
           count += 1;
           return item;

--- a/test/SimpleTransformIterator-test.js
+++ b/test/SimpleTransformIterator-test.js
@@ -9,6 +9,8 @@ import {
   scheduleTask,
   MappingIterator,
   FilteringIterator,
+  SkippingIterator,
+  LimitingIterator,
 } from '../dist/asynciterator.js';
 
 import { EventEmitter } from 'events';
@@ -1349,7 +1351,7 @@ describe('SimpleTransformIterator', () => {
         });
 
         it('should be a SimpleTransformIterator', () => {
-          result.should.be.an.instanceof(SimpleTransformIterator);
+          result.should.be.an.instanceof(SkippingIterator);
         });
 
         it('should skip the given number of items', () => {
@@ -1379,7 +1381,7 @@ describe('SimpleTransformIterator', () => {
         });
 
         it('should be a SimpleTransformIterator', () => {
-          result.should.be.an.instanceof(SimpleTransformIterator);
+          result.should.be.an.instanceof(LimitingIterator);
         });
 
         it('should take the given number of items', () => {

--- a/test/SimpleTransformIterator-test.js
+++ b/test/SimpleTransformIterator-test.js
@@ -7,6 +7,8 @@ import {
   ArrayIterator,
   IntegerIterator,
   scheduleTask,
+  MappingIterator,
+  FilteringIterator,
 } from '../dist/asynciterator.js';
 
 import { EventEmitter } from 'events';
@@ -1110,8 +1112,8 @@ describe('SimpleTransformIterator', () => {
           result.on('end', done);
         });
 
-        it('should be a SimpleTransformIterator', () => {
-          result.should.be.an.instanceof(SimpleTransformIterator);
+        it('should be a MappingIterator', () => {
+          result.should.be.an.instanceof(MappingIterator);
         });
 
         it('should execute the map function on all items in order', () => {
@@ -1146,7 +1148,7 @@ describe('SimpleTransformIterator', () => {
         });
 
         it('should be a SimpleTransformIterator', () => {
-          result.should.be.an.instanceof(SimpleTransformIterator);
+          result.should.be.an.instanceof(MappingIterator);
         });
 
         it('should execute the map function on all items in order', () => {
@@ -1185,7 +1187,7 @@ describe('SimpleTransformIterator', () => {
         });
 
         it('should be a SimpleTransformIterator', () => {
-          result.should.be.an.instanceof(SimpleTransformIterator);
+          result.should.be.an.instanceof(FilteringIterator);
         });
 
         it('should execute the filter function on all items in order', () => {
@@ -1219,7 +1221,7 @@ describe('SimpleTransformIterator', () => {
         });
 
         it('should be a SimpleTransformIterator', () => {
-          result.should.be.an.instanceof(SimpleTransformIterator);
+          result.should.be.an.instanceof(FilteringIterator);
         });
 
         it('should execute the filter function on all items in order', () => {


### PR DESCRIPTION
Supercedes #48 
Supercedes #50 

Makes use of [this](https://github.com/RubenVerborgh/AsyncIterator/pull/50#pullrequestreview-922328793) suggestion by @RubenVerborgh to provide the ~2x speedup to chained maps and transforms; without having the problems associated with immutability (to give you a sense, the test suite is now running at ~600ms on my machine vs ~1000ms before).
