### PR TITLE
chore: SyncUnionIterator

### DIFF
--- a/asynciterator.ts
+++ b/asynciterator.ts
@@ -1568,7 +1568,9 @@ export class SyncUnionIterator<T> extends AsyncIterator<T> {
       this._sources.push(source);
       source._destination = this;
       source.on('error', destinationEmitError);
-      source.on('readable', () => { this.readable = true });
+      source.on('readable', () => {
+        this.readable = true;
+      });
       source.on('end', destinationRemoveEmptySources);
     }
   }
@@ -1582,7 +1584,7 @@ export class SyncUnionIterator<T> extends AsyncIterator<T> {
       return !source.done;
     });
     if (!this._pending && this._sources.length === 0)
-        this.close();
+      this.close();
   }
 
   // Reads items from the next sources
@@ -1592,7 +1594,7 @@ export class SyncUnionIterator<T> extends AsyncIterator<T> {
       const item = this._sources[this._currentSource].read();
       // Attempt to read an item from that source
       if (item !== null)
-        return item
+        return item;
       this._currentSource = (this._currentSource + 1) % this._sources.length;
       // this._currentSource += 1
     }

--- a/asynciterator.ts
+++ b/asynciterator.ts
@@ -1508,6 +1508,99 @@ export class MultiTransformIterator<S, D = S> extends TransformIterator<S, D> {
   }
 }
 
+export class SyncUnionIterator<T> extends AsyncIterator<T> {
+  private _sources : InternalSource<T>[] = [];
+  private _pending? : { sources?: AsyncIterator<MaybePromise<AsyncIterator<T>>> };
+  private _currentSource = 0;
+
+  /**
+    Creates a new `SyncUnionIterator`.
+    @param {module:asynciterator.AsyncIterator|Array} [sources] The sources to read from
+    @param {object} [options] Settings of the iterator
+  */
+  constructor(sources: AsyncIteratorOrArray<AsyncIterator<T>> |
+                       AsyncIteratorOrArray<Promise<AsyncIterator<T>>> |
+                       AsyncIteratorOrArray<MaybePromise<AsyncIterator<T>>>) {
+    super();
+
+    // Sources have been passed as an iterator
+    if (isEventEmitter(sources)) {
+      sources.on('error', error => this.emit('error', error));
+      this._pending = { sources: sources as AsyncIterator<MaybePromise<AsyncIterator<T>>> };
+      this._loadSources();
+    }
+    // Sources have been passed as a non-empty array
+    else if (Array.isArray(sources) && sources.length > 0) {
+      for (const source of sources)
+        this._addSource(source as MaybePromise<InternalSource<T>>);
+    }
+  }
+
+  // Loads sources passed as an iterator
+  protected _loadSources() {
+    // Obtain sources iterator
+    const sources = this._pending!.sources!;
+    delete this._pending!.sources;
+
+    // Close immediately if done
+    if (sources.done) {
+      delete this._pending;
+      this.close();
+    }
+    // Otherwise, set up source reading
+    else {
+      sources.on('data', source => {
+        this._addSource(source as MaybePromise<InternalSource<T>>);
+      });
+      sources.on('end', () => {
+        delete this._pending;
+        if (this._sources.length === 0)
+          this.close();
+      });
+    }
+  }
+
+  // Adds the given source to the internal sources array
+  public _addSource(source: MaybePromise<InternalSource<T>>) {
+    if (isPromise(source))
+      source = wrap<T>(source) as any as InternalSource<T>;
+    if (!source.done) {
+      this._sources.push(source);
+      source._destination = this;
+      source.on('error', destinationEmitError);
+      source.on('readable', () => { this.readable = true });
+      source.on('end', destinationRemoveEmptySources);
+    }
+  }
+
+  // Removes sources that will no longer emit items
+  protected _removeEmptySources() {
+    this._sources = this._sources.filter((source, index) => {
+      // Adjust the index of the current source if needed
+      if (source.done && index <= this._currentSource)
+        this._currentSource--;
+      return !source.done;
+    });
+    if (!this._pending && this._sources.length === 0)
+        this.close();
+  }
+
+  // Reads items from the next sources
+  public read(): T | null {
+    for (let i = 0; i < this._sources.length; i++) {
+      // this._currentSource = (this._currentSource + 1) % this._sources.length;
+      const item = this._sources[this._currentSource].read();
+      // Attempt to read an item from that source
+      if (item !== null)
+        return item
+      this._currentSource = (this._currentSource + 1) % this._sources.length;
+      // this._currentSource += 1
+    }
+
+    return null;
+  }
+}
+
 /**
   An iterator that generates items by reading from multiple other iterators.
   @extends module:asynciterator.BufferedIterator


### PR DESCRIPTION
Resolves #52 

Creates an 8x perf improvement with 800ms to run the following vs 100ms to run with the `SyncUnionIterator`.

```ts
const it = new UnionIterator([range(0, 2_000_000), range(0, 2_000_000)]);

const start = Date.now();

it.on('data', () => {})
.on('end', () => {
  const end = Date.now();
  console.log(end - start)
})
```

@RubenVerborgh @jacoscaz This is a draft and the following decisions need to be made on it:
 - Should `UnionIterator` just be replaced with `SyncUnionIterator`s (I think it should)
 - If not, which should `union` use
 
This is a draft because I am yet to write a test suite for this


