### PR TITLE
feat: wrapIterator

### DIFF
--- a/asynciterator.ts
+++ b/asynciterator.ts
@@ -1852,6 +1852,22 @@ class HistoryReader<T> {
   }
 }
 
+class WrapIterator<T> extends AsyncIterator<T> {
+  constructor(private source: Iterator<T>) {
+    super();
+    this.readable = true;
+  }
+
+  read(): T | null {
+    const item = this.source.next();
+    if (item.done) {
+      this.close();
+      return null;
+    }
+    return item.value;
+  }
+}
+
 /**
   Creates an iterator that wraps around a given iterator or readable stream.
   Use this to convert an iterator-like object into a full-featured AsyncIterator.
@@ -1863,6 +1879,18 @@ class HistoryReader<T> {
 */
 export function wrap<T>(source: EventEmitter | Promise<EventEmitter>, options?: TransformIteratorOptions<T>) {
   return new TransformIterator<T>(source as AsyncIterator<T> | Promise<AsyncIterator<T>>, options);
+}
+
+/**
+  Creates an iterator that wraps around a given synchronous iterator.
+  Use this to convert an iterator-like object into a full-featured AsyncIterator.
+  After this operation, only read the returned iterator instead of the given one.
+  @function
+  @param {Iterator} [source] The source this iterator generates items from
+  @returns {module:asynciterator.AsyncIterator} A new iterator with the items from the given iterator
+*/
+export function wrapIterator<T>(source: Iterator<T>) {
+  return new WrapIterator(source);
 }
 
 /**

--- a/test/WrapIterator-test.js
+++ b/test/WrapIterator-test.js
@@ -1,0 +1,13 @@
+import {
+  wrapIterator,
+} from '../dist/asynciterator.js';
+
+describe('wrapIterator', () => {
+  it('Should wrap correctly', async () => {
+    (await wrapIterator((function * () {
+      yield 1;
+      yield 2;
+      yield 3;
+    })()).toArray()).should.deep.equal([1, 2, 3]);
+  });
+});


### PR DESCRIPTION
See https://github.com/comunica/comunica/issues/965 especially in light of https://github.com/rdfjs/N3.js/pull/275.

Once this and all of the other open PRs around fastIterators are closed, this should mean that Comunica will no longer store unecessary copies of matches in various arrays/buffers throughout the engine!
