### PR TITLE
feat: faster wrapping

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -20,7 +20,7 @@
 
   rules: {
     // Best Practices
-    accessor-pairs: error,
+    accessor-pairs: off,
     array-callback-return: error,
     block-scoped-var: error,
     class-methods-use-this: off,
@@ -66,9 +66,10 @@
     no-octal-escape: error,
     no-param-reassign: off,
     no-proto: error,
-    no-redeclare: error,
+    no-redeclare: off,
+    "@typescript-eslint/no-redeclare": ["error"],
     no-restricted-properties: error,
-    no-return-assign: error,
+    no-return-assign: off,
     no-return-await: error,
     no-script-url: error,
     no-self-assign: error,

--- a/.eslintrc
+++ b/.eslintrc
@@ -69,7 +69,7 @@
     no-redeclare: off,
     "@typescript-eslint/no-redeclare": ["error"],
     no-restricted-properties: error,
-    no-return-assign: off,
+    no-return-assign: error,
     no-return-await: error,
     no-script-url: error,
     no-self-assign: error,

--- a/asynciterator.ts
+++ b/asynciterator.ts
@@ -2050,11 +2050,11 @@ export class WrappingIterator<T> extends AsyncIterator<T> {
 
     // Enable reading from source
     this._source = source;
-    this.readable = true;
+    this.readable = source.readable !== false;
   }
 
   read(): T | null {
-    if (this._source !== null) {
+    if (this._source !== null && this._source.readable !== false) {
       const item = this._source.read();
       if (item !== null)
         return item;

--- a/asynciterator.ts
+++ b/asynciterator.ts
@@ -2000,9 +2000,12 @@ export class WrappingIterator<T> extends AsyncIterator<T> {
       source = new EventEmitter() as any;
       source.read = (): T | null => {
         if (iterator !== null) {
-          const item = iterator.next();
-          if (!item.done)
-            return item.value;
+          // Skip any null values inside of the iterator
+          let next: IteratorResult<T>;
+          while (!(next = iterator.next()).done) {
+            if (next.value !== null)
+              return next.value;
+          }
           // No remaining values, so stop iterating
           iterator = null;
           this.close();

--- a/asynciterator.ts
+++ b/asynciterator.ts
@@ -320,7 +320,7 @@ export class AsyncIterator<T> extends EventEmitter {
     const items: T[] = [];
     const limit = typeof options?.limit === 'number' ? options.limit : Infinity;
 
-    return limit <= 0 ? Promise.resolve(items) : new Promise<T[]>((resolve, reject) => {
+    return this.ended || limit <= 0 ? Promise.resolve(items) : new Promise<T[]>((resolve, reject) => {
       // Collect and return all items up to the limit
       const resolveItems = () => resolve(items);
       const pushItem = (item: T) => {
@@ -1203,6 +1203,10 @@ export class TransformIterator<S, D = S> extends BufferedIterator<D> {
   }
 
   set source(value: AsyncIterator<S> | undefined) {
+    // Do not change sources if the iterator is already done
+    if (this.done)
+      return;
+
     // Validate and set source
     const source = this._source = this._validateSource(value);
     source._destination = this;
@@ -1784,6 +1788,10 @@ export class ClonedIterator<T> extends TransformIterator<T> {
   }
 
   set source(value: AsyncIterator<T> | undefined) {
+    // Do not change sources if the iterator is already done
+    if (this.done)
+      return;
+
     // Validate and set the source
     const source = this._source = this._validateSource(value);
     // Create a history reader for the source if none already existed
@@ -1991,6 +1999,10 @@ export class WrappingIterator<T> extends AsyncIterator<T> {
   }
 
   protected set source(source: InternalSource<T>) {
+    // Do not change sources if the iterator is already done
+    if (this.done)
+      return;
+
     // Process an iterable source
     if (isIterable(source))
       source = source[Symbol.iterator]() as any;

--- a/test/ArrayIterator-test.js
+++ b/test/ArrayIterator-test.js
@@ -2,6 +2,7 @@ import {
   AsyncIterator,
   ArrayIterator,
   fromArray,
+  wrap,
 } from '../dist/asynciterator.js';
 
 import { EventEmitter } from 'events';
@@ -28,6 +29,23 @@ describe('ArrayIterator', () => {
     describe('the result when called through `fromArray`', () => {
       let instance;
       before(() => { instance = fromArray(); });
+
+      it('should be an ArrayIterator object', () => {
+        instance.should.be.an.instanceof(ArrayIterator);
+      });
+
+      it('should be an AsyncIterator object', () => {
+        instance.should.be.an.instanceof(AsyncIterator);
+      });
+
+      it('should be an EventEmitter object', () => {
+        instance.should.be.an.instanceof(EventEmitter);
+      });
+    });
+
+    describe('the result when called through `wrap`', () => {
+      let instance;
+      before(() => { instance = wrap([]); });
 
       it('should be an ArrayIterator object', () => {
         instance.should.be.an.instanceof(ArrayIterator);

--- a/test/AsyncIterator-test.js
+++ b/test/AsyncIterator-test.js
@@ -5,6 +5,8 @@ import {
   ENDED,
   DESTROYED,
   scheduleTask,
+  isPromise,
+  isIterator,
 } from '../dist/asynciterator.js';
 
 import { EventEmitter } from 'events';
@@ -1305,6 +1307,28 @@ describe('AsyncIterator', () => {
       it('should return an array with five elements', () => {
         expect(result).deep.to.equal([1, 2, 3, 4, 5]);
       });
+    });
+  });
+});
+
+describe('Type-checking functions', () => {
+  describe('isPromise', () => {
+    it('returns false for null', () => {
+      expect(isPromise(null)).to.equal(false);
+    });
+
+    it('returns true for a Promise', () => {
+      expect(isPromise(Promise.resolve(0))).to.equal(true);
+    });
+  });
+
+  describe('isIterator', () => {
+    it('returns false for null', () => {
+      expect(isIterator(null)).to.equal(false);
+    });
+
+    it('returns true for an iterator', () => {
+      expect(isIterator([][Symbol.iterator]())).to.equal(true);
     });
   });
 });

--- a/test/ClonedIterator-test.js
+++ b/test/ClonedIterator-test.js
@@ -83,6 +83,10 @@ describe('ClonedIterator', () => {
         clone.close();
       });
 
+      it('should not do anything when a source is set', () => {
+        clone.source = {};
+      });
+
       it('should have undefined as `source` property', () => {
         expect(clone.source).to.be.undefined;
       });

--- a/test/EmptyIterator-test.js
+++ b/test/EmptyIterator-test.js
@@ -2,6 +2,7 @@ import {
   AsyncIterator,
   EmptyIterator,
   empty,
+  wrap,
 } from '../dist/asynciterator.js';
 
 import { EventEmitter } from 'events';
@@ -28,6 +29,23 @@ describe('EmptyIterator', () => {
     describe('the result when called through `.empty`', () => {
       let instance;
       before(() => { instance = empty(); });
+
+      it('should be an EmptyIterator object', () => {
+        instance.should.be.an.instanceof(EmptyIterator);
+      });
+
+      it('should be an AsyncIterator object', () => {
+        instance.should.be.an.instanceof(AsyncIterator);
+      });
+
+      it('should be an EventEmitter object', () => {
+        instance.should.be.an.instanceof(EventEmitter);
+      });
+    });
+
+    describe('the result when called through `.wrap`', () => {
+      let instance;
+      before(() => { instance = wrap(); });
 
       it('should be an EmptyIterator object', () => {
         instance.should.be.an.instanceof(EmptyIterator);

--- a/test/MappingIterator-test.js
+++ b/test/MappingIterator-test.js
@@ -542,7 +542,6 @@ describe('MappingIterator', () => {
 
   describe('A chain of maps and filters', () => {
     for (const iteratorGen of [() => range(0, 2), () => fromArray([0, 1, 2]), () => wrap(range(0, 2))]) {
-      // eslint-disable-next-line no-loop-func
       describe(`with ${iteratorGen()}`, () => {
         let iterator;
 

--- a/test/TransformIterator-test.js
+++ b/test/TransformIterator-test.js
@@ -35,7 +35,7 @@ describe('TransformIterator', () => {
 
     describe('the result when called through `wrap`', () => {
       let instance;
-      before(() => { instance = wrap(); });
+      before(() => { instance = wrap({}, {}); });
 
       it('should be an TransformIterator object', () => {
         instance.should.be.an.instanceof(TransformIterator);

--- a/test/WrappingIterator-test.js
+++ b/test/WrappingIterator-test.js
@@ -86,6 +86,25 @@ describe('WrappingIterator', () => {
     });
   });
 
+  describe('with an iterable that emits null values', () => {
+    let iterator;
+    beforeEach(() => {
+      iterator = new WrappingIterator((function * () {
+        yield 0;
+        yield null;
+        yield null;
+        yield 1;
+        yield null;
+        yield null;
+      })());
+    });
+
+    it('should skip null values', async () => {
+      const arr = await iterator.toArray();
+      expect(arr).to.deep.equal([0, 1]);
+    });
+  });
+
   describe('with an iterator that emits one item', () => {
     let iterator;
     before(() => {

--- a/test/WrappingIterator-test.js
+++ b/test/WrappingIterator-test.js
@@ -1,0 +1,401 @@
+import {
+  AsyncIterator,
+  ArrayIterator,
+  WrappingIterator,
+  TransformIterator,
+  EmptyIterator,
+  IntegerIterator,
+  fromIterable,
+  fromIterator,
+  wrap,
+} from '../dist/asynciterator.js';
+
+import { EventEmitter } from 'events';
+import { Readable } from 'stream';
+
+describe('WrappingIterator', () => {
+  describe('The WrappingIterator function', () => {
+    describe('the result when called with `new`', () => {
+      let instance;
+      before(() => { instance = new WrappingIterator(new EmptyIterator()); });
+
+      it('should be an WrappingIterator object', () => {
+        instance.should.be.an.instanceof(WrappingIterator);
+      });
+
+      it('should be an AsyncIterator object', () => {
+        instance.should.be.an.instanceof(AsyncIterator);
+      });
+
+      it('should be an EventEmitter object', () => {
+        instance.should.be.an.instanceof(EventEmitter);
+      });
+    });
+  });
+
+  describe('with an empty iterable', () => {
+    let iterator;
+    before(() => { iterator = fromIterable((function * () { /* empty */ })()); });
+
+    it('should be readable', () => {
+      expect(iterator.readable).to.be.true;
+    });
+
+    it('should end after the first invocation of read, which should return null', done => {
+      expect(iterator.once('end', done).read()).to.equal(null);
+    });
+
+    it('should not be readable anymore', () => {
+      expect(iterator.readable).to.equal(false);
+    });
+  });
+
+  describe('with an iterable that emits one item', () => {
+    let iterator;
+    before(() => { iterator = fromIterable((function * () { yield 'first'; })()); });
+
+    it('should be readable', () => {
+      expect(iterator.readable).to.be.true;
+    });
+
+    it('should read the first item', () => {
+      expect(iterator.read()).to.equal('first');
+    });
+
+    it('should end after the second invocation of read, which should return null', done => {
+      expect(iterator.on('end', done).read()).to.equal(null);
+    });
+
+    it('should not be readable anymore', () => {
+      expect(iterator.readable).to.be.false;
+    });
+  });
+
+  describe('with an iterable that emits 10 items', () => {
+    let iterator;
+    beforeEach(() => {
+      iterator = new WrappingIterator((function * () {
+        for (let i = 0; i < 10; i += 1)
+          yield i;
+      })());
+    });
+
+    it('should emit all items', async () => {
+      const arr = await iterator.toArray();
+      expect(arr).to.deep.equal([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+    });
+  });
+
+  describe('with an iterator that emits one item', () => {
+    let iterator;
+    before(() => {
+      let done = false;
+      iterator = fromIterator({
+        next: () => {
+          if (done)
+            return { done };
+          done = true;
+          return { value: 'first' };
+        },
+      });
+    });
+
+    it('should be readable', () => {
+      expect(iterator.readable).to.be.true;
+    });
+
+    it('should read the first item', () => {
+      expect(iterator.read()).to.equal('first');
+    });
+
+    it('should end after the second invocation of read, which should return null', done => {
+      expect(iterator.on('end', done).read()).to.equal(null);
+    });
+
+    it('should not be readable anymore', () => {
+      expect(iterator.readable).to.be.false;
+    });
+  });
+
+  describe('with an array source', () => {
+    let iterator, source;
+    before(() => {
+      source = [0, 1, 2, 3, 4];
+      iterator = new WrappingIterator(source);
+    });
+
+    it('should emit all items', async () => {
+      expect(await iterator.toArray()).to.deep.equal([0, 1, 2, 3, 4]);
+    });
+  });
+
+  describe('with an array source', () => {
+    let iterator, source;
+    before(() => {
+      source = Promise.resolve([0, 1, 2, 3, 4]);
+      iterator = new WrappingIterator(source);
+    });
+
+    it('should emit all items', async () => {
+      expect(await iterator.toArray()).to.deep.equal([0, 1, 2, 3, 4]);
+    });
+  });
+
+  describe('with a stream.Readable source', () => {
+    let iterator, source;
+    before(() => {
+      source = Readable.from([0, 1, 2, 3, 4]);
+      iterator = new WrappingIterator(source);
+    });
+
+    it('should emit all items', async () => {
+      expect(await iterator.toArray()).to.deep.equal([0, 1, 2, 3, 4]);
+    });
+  });
+
+  describe('with a promisified stream.Readable source', () => {
+    let iterator, source;
+    before(() => {
+      source = Promise.resolve(Readable.from([0, 1, 2, 3, 4]));
+      iterator = new WrappingIterator(source);
+    });
+
+    it('should emit all items', async () => {
+      expect(await iterator.toArray()).to.deep.equal([0, 1, 2, 3, 4]);
+    });
+  });
+
+  describe('with an AsyncIterator source', () => {
+    let iterator, source;
+    before(() => {
+      source = new ArrayIterator([0, 1, 2, 3, 4]);
+      iterator = new WrappingIterator(source);
+    });
+
+    it('should emit all items', async () => {
+      expect(await iterator.toArray()).to.deep.equal([0, 1, 2, 3, 4]);
+    });
+  });
+
+  describe('with a promisified AsyncIterator source', () => {
+    let iterator, source;
+    before(() => {
+      source = Promise.resolve(new ArrayIterator([0, 1, 2, 3, 4]));
+      iterator = new WrappingIterator(source);
+    });
+
+    it('should emit all items', async () => {
+      expect(await iterator.toArray()).to.deep.equal([0, 1, 2, 3, 4]);
+    });
+  });
+
+  describe('with an EmptyIterator source that never emits a readable event', () => {
+    let iterator;
+    before(() => {
+      iterator = new WrappingIterator(new EmptyIterator());
+      captureEvents(iterator, 'readable', 'end');
+    });
+
+    it('should have emitted the end event', () => {
+      expect(iterator._eventCounts.end).to.equal(1);
+    });
+  });
+
+  describe('with a promisified IntegerIterator', () => {
+    let iterator, source;
+    before(() => {
+      source = Promise.resolve(new IntegerIterator({ start: 0, step: 1, end: 4 }));
+      iterator = new WrappingIterator(source);
+      captureEvents(iterator, 'readable');
+    });
+
+    it('should have emitted the readable event', () => {
+      expect(iterator._eventCounts.readable).to.be.gt(0);
+    });
+
+    it('should emit all items', async () => {
+      expect(await iterator.toArray()).to.deep.equal([0, 1, 2, 3, 4]);
+    });
+  });
+
+  describe('with a buffering AsyncIterator source with autoStart: false', () => {
+    let iterator, source;
+    before(() => {
+      source = new TransformIterator(new ArrayIterator([0, 1, 2, 3, 4]), { autoStart: false });
+      iterator = new WrappingIterator(source);
+      captureEvents(iterator, 'readable');
+    });
+
+    it('should have emitted the readable event', () => {
+      expect(iterator._eventCounts.readable).to.be.gt(0);
+    });
+
+    it('should emit all items', async () => {
+      expect(await iterator.toArray()).to.deep.equal([0, 1, 2, 3, 4]);
+    });
+  });
+
+  describe('with a buffering AsyncIterator source with autoStart: true', () => {
+    let iterator;
+    let source;
+
+    before(() => {
+      source = new TransformIterator(new ArrayIterator([0, 1, 2, 3, 4]), { autoStart: true });
+      iterator = new WrappingIterator(source);
+      captureEvents(iterator, 'readable');
+    });
+
+    it('should have emitted the readable event', () => {
+      expect(iterator._eventCounts.readable).to.be.gt(0);
+    });
+
+    it('should emit all items', async () => {
+      expect(await iterator.toArray()).to.deep.equal([0, 1, 2, 3, 4]);
+    });
+  });
+
+  describe('with a rejecting promise as a source', () => {
+    it('should emit the error', done => {
+      const error = new Error('some error');
+      const iterator = new WrappingIterator(Promise.reject(error));
+      iterator.once('error', e => {
+        expect(e).to.equal(error);
+        done();
+      });
+    });
+  });
+
+  describe('with a stream.Readable source that emits an error', () => {
+    it('should relay the error downstream', done => {
+      const error = new Error('some error');
+      const source = new Readable({
+        read() {
+          return null;
+        },
+      });
+      const iterator = new WrappingIterator(source);
+      iterator.once('error', e => {
+        expect(e).to.equal(error);
+        done();
+      });
+      source.emit('error', error);
+    });
+  });
+});
+
+describe('wrap', () => {
+  describe('with a stream.Readable source', () => {
+    let iterator;
+    let source;
+    before(() => {
+      source = Readable.from([0, 1, 2, 3, 4]);
+      iterator = wrap(source);
+    });
+
+    it('should return an instance of WrappingIterator', async () => {
+      expect(iterator).to.be.instanceof(WrappingIterator);
+    });
+
+    it('should emit all items', async () => {
+      expect(await iterator.toArray()).to.deep.equal([0, 1, 2, 3, 4]);
+    });
+  });
+
+  describe('with a promisified stream.Readable source', () => {
+    let iterator, source;
+    before(() => {
+      source = Promise.resolve(Readable.from([0, 1, 2, 3, 4]));
+      iterator = wrap(source);
+    });
+
+    it('should return an instance of WrappingIterator', async () => {
+      expect(iterator).to.be.instanceof(WrappingIterator);
+    });
+
+    it('should emit all items', async () => {
+      expect(await iterator.toArray()).to.deep.equal([0, 1, 2, 3, 4]);
+    });
+  });
+
+  describe('with an AsyncIterator source', () => {
+    let iterator, source;
+    before(() => {
+      source = new ArrayIterator([0, 1, 2, 3, 4]);
+      iterator = wrap(source);
+    });
+
+    it('should return the source itself', () => {
+      expect(iterator).to.equal(source);
+    });
+
+    it('should emit all items', async () => {
+      expect(await iterator.toArray()).to.deep.equal([0, 1, 2, 3, 4]);
+    });
+  });
+
+  describe('with a rejecting promise as a source', () => {
+    it('should return an instance of WrappingIterator', done => {
+      const err = new Error('some error');
+      const iterator = wrap(Promise.reject(err));
+      expect(iterator).to.be.instanceof(WrappingIterator);
+      iterator.once('error', _err => {
+        expect(_err).to.equal(err);
+        done();
+      });
+    });
+  });
+
+  describe('with an invalid source', () => {
+    it('should throw an error', done => {
+      try {
+        wrap({});
+      }
+      catch (err) {
+        expect(err.message).to.match(/^Invalid source/);
+        done();
+      }
+    });
+  });
+
+  describe('with an instance of Iterator as the source', () => {
+    let source;
+    let iterator;
+    before(() => {
+      source = (function * () {
+        for (let i = 0; i < 5; i += 1)
+          yield i;
+      }());
+      iterator = wrap(source);
+    });
+
+    it('should return an instance of WrappingIterator', () => {
+      expect(iterator).to.be.instanceof(WrappingIterator);
+    });
+
+    it('should emit all items', async () => {
+      expect(await iterator.toArray()).to.deep.equal([0, 1, 2, 3, 4]);
+    });
+  });
+
+  describe('with an instance of Iterable as the source', () => {
+    let source;
+    let iterator;
+    before(() => {
+      source = {
+        *[Symbol.iterator]() {
+          for (let i = 0; i < 5; i += 1)
+            yield i;
+        },
+      };
+      iterator = wrap(source);
+    });
+
+    it('should return an instance of WrappingIterator', () => {
+      expect(iterator).to.be.instanceof(WrappingIterator);
+    });
+
+    it('should emit all items', async () => {
+      expect(await iterator.toArray()).to.deep.equal([0, 1, 2, 3, 4]);
+    });
+  });
+});

--- a/test/WrappingIterator-test.js
+++ b/test/WrappingIterator-test.js
@@ -148,7 +148,35 @@ describe('WrappingIterator', () => {
     });
   });
 
+  describe('with a promise that resolves after closing', () => {
+    let iterator;
+    before(() => {
+      let resolve;
+      iterator = new WrappingIterator(new Promise(r => {
+        resolve = r;
+      }));
+      iterator.close();
+      resolve([1, 2, 3]);
+    });
+
+    it('should not emit any items', async () => {
+      expect(await iterator.toArray()).to.deep.equal([]);
+    });
+  });
+
   describe('with an array source', () => {
+    let iterator, source;
+    before(() => {
+      source = [0, 1, 2, 3, 4];
+      iterator = new WrappingIterator(source);
+    });
+
+    it('should emit all items', async () => {
+      expect(await iterator.toArray()).to.deep.equal([0, 1, 2, 3, 4]);
+    });
+  });
+
+  describe('with a promisified array source', () => {
     let iterator, source;
     before(() => {
       source = Promise.resolve([0, 1, 2, 3, 4]);


### PR DESCRIPTION
This PR covers step 2. in the plan described in https://github.com/RubenVerborgh/AsyncIterator/issues/44#issuecomment-1086950726 and aims to 1) lower the overhead of the `wrap()` function and 2) expand support to additional types of sources (namely `Iterator` and `Iterable` objects).

The rationale for this PR is taking the onus of figuring out how to best wrap common types of data sources away from users of this library. Users should be able to expect `wrap()` to use the strategy that is most appropriate for any given source (as long as it's a supported source).

Performance-wise, this PR does two things:

1) It introduces source-specific iterators that synchronously read from their sources, skipping the internal buffering done by `TransformIterator` (i.e. the class currently used for wrapping)

2) It introduces a specific option that allows `AsyncIterator` instances to fall-through as they are, with no wrapping applied

The following test, admittedly naive, takes ~116 ms with the current `main` branch and ~8 ms with this PR (`letIteratorThrough` makes virtually no difference). This mostly highlight the difference made by skipping `TransformIterator`'s internal buffering.

```typescript
let i = 0;
const arr = new Array(200_000).fill(true).map(() => i++);
const source = new ArrayIterator(arr);
const opts = { letIteratorThrough: false };
const then = Date.now();
wrap(source, opts).on('data', () => {}).on('end', () => {
  console.log('elapsed', Date.now() - then, 'ms');
});
```

Things become much more interesting when we consider what happens with a chain established by `wrap()`ing:

```typescript
let i = 0;
const arr = new Array(200_000).fill(true).map(() => i++);
const source = new ArrayIterator(arr);
const opts = { letIteratorThrough: false };
const then = Date.now();
wrap(wrap(wrap(wrap(source, opts), opts), opts), opts).on('data', () => {}).on('end', () => {
  console.log('elapsed', Date.now() - then, 'ms');
});
```

The above test takes ~250 ms with the current `main` branch, ~ 15 ms with this PR and `letIteratorThrough: false`, ~ 8 ms with this PR and `letIteratorThrough: true`. I haven't seen consistent differences with or without warmups.

My use case is the optimization of the interface between [quadstore](https://github.com/belayeng/quadstore), which implements the RDF/JS `Source` interface, and [comunica](https://comunica.dev), through which the former can be queried via SPARQL: https://github.com/comunica/comunica/blob/a2f31270778730911bd0bdf8b8c7ade567153319/packages/actor-rdf-resolve-quad-pattern-rdfjs-source/lib/RdfJsQuadSource.ts#L29 .

As many algebraic operation (matching, joining, ...) are happening in-memory, thus requiring the streaming of large amounts of quads from the persistence layer into the engine, removing even just one layer of indirection/buffering can make a significant difference. 