### PR TITLE
draft: synchronousTransformIterator

### DIFF
--- a/test/SimpleTransformIterator-test.js
+++ b/test/SimpleTransformIterator-test.js
@@ -1198,10 +1198,6 @@ describe('SimpleTransformIterator', () => {
           result.on('end', done);
         });
 
-        it('should be a SimpleTransformIterator', () => {
-          result.should.be.an.instanceof(SimpleTransformIterator);
-        });
-
         it('should take the given number of items', () => {
           items.should.deep.equal(['a', 'b', 'c']);
         });


### PR DESCRIPTION
As discussed in https://github.com/RubenVerborgh/AsyncIterator/pull/75#issuecomment-1168219877.

TODOs
 - Add more coverage
 - See if https://github.com/RubenVerborgh/AsyncIterator/blob/3a5b62cf8ca00e60013b6aa7c1e692b26fcb6964/asynciterator.ts#L905-L911 is necessary. @RubenVerborgh the question here is - can we just assume the `root` is `.readable` if the parent source is `.readable`. If we assume that all of the intermediary sources are `SynchronousTransformIterator`s as is the case when doing chaining then this will be true; but I am not sure if we should be making this assumption.
 
Quick testing indicates that this results in a ~2x performance increase on the tests in #75 