### PR TITLE
Symbol for _destination property

### DIFF
--- a/test/ClonedIterator-test.js
+++ b/test/ClonedIterator-test.js
@@ -5,6 +5,7 @@ import {
   BufferedIterator,
   EmptyIterator,
   ArrayIterator,
+  DESTINATION,
 } from '../dist/asynciterator.js';
 
 import { EventEmitter } from 'events';
@@ -120,7 +121,7 @@ describe('ClonedIterator', () => {
   describe('Cloning an iterator that already has a destination', () => {
     it('should throw an exception', () => {
       const source = new AsyncIterator(), destination = new TransformIterator(source);
-      source.should.have.property('_destination', destination);
+      source.should.have.property(DESTINATION, destination);
       (() => source.clone()).should.throw('The source already has a destination');
     });
   });

--- a/test/TransformIterator-test.js
+++ b/test/TransformIterator-test.js
@@ -6,6 +6,7 @@ import {
   TransformIterator,
   wrap,
   scheduleTask,
+  DESTINATION,
 } from '../dist/asynciterator.js';
 
 import { EventEmitter } from 'events';
@@ -359,7 +360,7 @@ describe('TransformIterator', () => {
       });
 
       it('should remove itself as destination from the source', () => {
-        source.should.not.have.key('_destination');
+        source.should.not.have.key(DESTINATION);
       });
     });
   });
@@ -466,7 +467,7 @@ describe('TransformIterator', () => {
       });
 
       it('should remove itself as destination from the source', () => {
-        source.should.not.have.key('_destination');
+        source.should.not.have.key(DESTINATION);
       });
     });
   });
@@ -575,7 +576,7 @@ describe('TransformIterator', () => {
       });
 
       it('should remove itself as destination from the source', () => {
-        source.should.not.have.key('_destination');
+        source.should.not.have.key(DESTINATION);
       });
     });
   });


### PR DESCRIPTION
This PR complements #63 (which should be merged first) by renaming the `_destination` property to a dedicated `Symbol`, guaranteed to be unique, so that we can never trigger property collisions when setting `_destination` on externally-provided source objects for which `isAsyncReadable(source) === true` at https://github.com/RubenVerborgh/AsyncIterator/blob/159ed2b09e599d03d574aec2c98b40ae416d168b/asynciterator.ts#L2030-L2043 .