### PR TITLE
fix: re-enable IterableSource options in wrap

### DIFF
--- a/asynciterator.ts
+++ b/asynciterator.ts
@@ -2089,7 +2089,8 @@ export class WrappingIterator<T> extends AsyncIterator<T> {
   @param {object} [options] Settings of the iterator
   @returns {module:asynciterator.AsyncIterator} A new iterator with the items from the given iterator
 */
-export function wrap<T>(source: null | undefined): AsyncIterator<T>;
+export function wrap<T>(source: null | undefined,
+                        options?: TransformIteratorOptions<T>): AsyncIterator<T>;
 export function wrap<T>(source: MaybePromise<IterableSource<T>>,
                         options?: TransformIteratorOptions<T>): AsyncIterator<T>;
 export function wrap<T>(source: MaybePromise<AsyncIterator<T>>,

--- a/asynciterator.ts
+++ b/asynciterator.ts
@@ -2090,7 +2090,8 @@ export class WrappingIterator<T> extends AsyncIterator<T> {
   @returns {module:asynciterator.AsyncIterator} A new iterator with the items from the given iterator
 */
 export function wrap<T>(source: null | undefined): AsyncIterator<T>;
-export function wrap<T>(source: MaybePromise<IterableSource<T>>): AsyncIterator<T>;
+export function wrap<T>(source: MaybePromise<IterableSource<T>>,
+                        options?: TransformIteratorOptions<T>): AsyncIterator<T>;
 export function wrap<T>(source: MaybePromise<AsyncIterator<T>>,
                         options?: TransformIteratorOptions<T>): AsyncIterator<T>;
 export function wrap<T>(source?: MaybePromise<IterableSource<T>> | null,


### PR DESCRIPTION
Prior to this fix uses of `wrap` following the pattern

```ts
const iterator = new EventEmitter();
wrap(iterator, { autoStart: false })
```

were breaking due to the fact that the type overloads did not include the optional option