### PR TITLE
Perf/fast unions

### DIFF
--- a/asynciterator.ts
+++ b/asynciterator.ts
@@ -1753,9 +1753,11 @@ export class UnionIterator<T> extends AsyncIterator<T> {
     while (this._size < this._maxParallelIterators && (iterator = _sources.read()) !== null) {
       // TODO - it would be nice to skip adding sources if it is a single or no
       // element iterator.
-      this._addSource(iterator);
-      if ((item = iterator.read()) !== null)
-        return item;
+      // if (!iterator.done) {
+        this._addSource(iterator);
+        if ((item = iterator.read()) !== null)
+          return item;
+      // }
     }
 
     if (this._size === 0 && this._sources.done)
@@ -1798,7 +1800,10 @@ function destinationRemoveEmptySources<T>(this: InternalSource<T>) {
 
     // else if (destination._size < destination._maxParallelIterators && destination._sources.readable) {
     // TODO: Add a test case for this
-    this.readable = true;
+    if (this.readable)
+      this.emit('readable')
+    else
+      this.readable = true;
     // TODO: Future performance improvement - continue re-filling the circular linked list
     // }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "c8": "^7.2.0",
         "chai": "^4.2.0",
         "eslint": "^8.0.0",
+        "event-emitter-promisify": "^1.1.0",
         "husky": "^4.2.5",
         "jaguarjs-jsdoc": "^1.1.0",
         "jsdoc": "^3.5.5",
@@ -1788,6 +1789,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/event-emitter-promisify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/event-emitter-promisify/-/event-emitter-promisify-1.1.0.tgz",
+      "integrity": "sha512-uyHG8gjwYGDlKoo0Txtx/u1HI1ubj0FK0rVqI4O0s1EymQm4iAEMbrS5B+XFlSaS8SZ3xzoKX+YHRZk8Nk/bXg==",
+      "dev": true
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -5459,6 +5466,12 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true
+    },
+    "event-emitter-promisify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/event-emitter-promisify/-/event-emitter-promisify-1.1.0.tgz",
+      "integrity": "sha512-uyHG8gjwYGDlKoo0Txtx/u1HI1ubj0FK0rVqI4O0s1EymQm4iAEMbrS5B+XFlSaS8SZ3xzoKX+YHRZk8Nk/bXg==",
       "dev": true
     },
     "fast-deep-equal": {

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "c8": "^7.2.0",
     "chai": "^4.2.0",
     "eslint": "^8.0.0",
+    "event-emitter-promisify": "^1.1.0",
     "husky": "^4.2.5",
     "jaguarjs-jsdoc": "^1.1.0",
     "jsdoc": "^3.5.5",

--- a/perf/UnionIterator-perf.js
+++ b/perf/UnionIterator-perf.js
@@ -1,0 +1,33 @@
+import { UnionIterator, range } from '../dist/asynciterator.js';
+import { promisifyEventEmitter } from 'event-emitter-promisify';
+
+let it;
+
+// Warmup
+
+console.time('For loop with 5x10^9 elems');
+for (let i = 0; i < 5_000_000_000; i++)
+  ;
+console.timeEnd('For loop with 5x10^9 elems');
+
+console.time('UnionIterator 2x10^7 iterators');
+for (let i = 0; i < 5; i++) {
+  it = new UnionIterator([range(0, 10_000_000), range(0, 10_000_000)]);
+  await promisifyEventEmitter(it.on('data', () => { /* noop */ }));
+}
+console.timeEnd('UnionIterator 2x10^7 iterators');
+
+console.time('UnionIterator 1000x500 iterators');
+for (let i = 0; i < 5; i++) {
+  it = new UnionIterator(range(0, 1000).map(() => range(0, 500)));
+  await promisifyEventEmitter(it.on('data', () => { /* noop */ }));
+}
+console.timeEnd('UnionIterator 1000x500 iterators');
+
+
+console.time('UnionIterator 1000x500 iterators - max parallelism of 1');
+for (let i = 0; i < 5; i++) {
+  it = new UnionIterator(range(0, 1000).map(() => range(0, 500)), { maxParallelIterators: 1 });
+  await promisifyEventEmitter(it.on('data', () => { /* noop */ }));
+}
+console.timeEnd('UnionIterator 1000x500 iterators - max parallelism of 1');

--- a/test/AsyncIterator-test.js
+++ b/test/AsyncIterator-test.js
@@ -7,6 +7,7 @@ import {
   scheduleTask,
   isPromise,
   isIterator,
+  range,
 } from '../dist/asynciterator.js';
 
 import { EventEmitter } from 'events';
@@ -1329,6 +1330,24 @@ describe('Type-checking functions', () => {
 
     it('returns true for an iterator', () => {
       expect(isIterator([][Symbol.iterator]())).to.equal(true);
+    });
+  });
+
+  describe('Testing #append', () => {
+    it('Should append an array', async () => {
+      expect(await range(0, 1).append([2, 3, 4]).toArray()).to.deep.equal([0, 1, 2, 3, 4]);
+    });
+    it('Should append an iterator', async () => {
+      expect(await range(0, 1).append(range(2, 4)).toArray()).to.deep.equal([0, 1, 2, 3, 4]);
+    });
+  });
+
+  describe('Testing #prepend', () => {
+    it('Should prepend an array', async () => {
+      expect(await range(0, 1).prepend([2, 3, 4]).toArray()).to.deep.equal([2, 3, 4, 0, 1]);
+    });
+    it('Should prepend an iterator', async () => {
+      expect(await range(0, 1).prepend(range(2, 4)).toArray()).to.deep.equal([2, 3, 4, 0, 1]);
     });
   });
 });

--- a/test/SimpleTransformIterator-test.js
+++ b/test/SimpleTransformIterator-test.js
@@ -1108,10 +1108,6 @@ describe('SimpleTransformIterator', () => {
           result.on('end', done);
         });
 
-        it('should be a SimpleTransformIterator', () => {
-          result.should.be.an.instanceof(SimpleTransformIterator);
-        });
-
         it('should prepend the items', () => {
           items.should.deep.equal(['i', 'ii', 'iii', 'a', 'b', 'c']);
         });
@@ -1138,10 +1134,6 @@ describe('SimpleTransformIterator', () => {
           result.on('end', done);
         });
 
-        it('should be a SimpleTransformIterator', () => {
-          result.should.be.an.instanceof(SimpleTransformIterator);
-        });
-
         it('should append the items', () => {
           items.should.deep.equal(['a', 'b', 'c', 'I', 'II', 'III']);
         });
@@ -1166,10 +1158,6 @@ describe('SimpleTransformIterator', () => {
         before(done => {
           result.on('data', item => { items.push(item); });
           result.on('end', done);
-        });
-
-        it('should be a SimpleTransformIterator', () => {
-          result.should.be.an.instanceof(SimpleTransformIterator);
         });
 
         it('should surround the items', () => {

--- a/test/UnionIterator-test.js
+++ b/test/UnionIterator-test.js
@@ -68,6 +68,27 @@ describe('UnionIterator', () => {
     (await toArray(iterator)).sort().should.eql([0, 1, 2]);
   });
 
+  it('should include all data from 0 sources - with maxParallelIterators: 1', async () => {
+    const iterator = new UnionIterator([
+    ], { maxParallelIterators: 1 });
+    (await toArray(iterator)).sort().should.eql([]);
+  });
+
+  it('should include all data from 1 non-empty source - with maxParallelIterators: 1', async () => {
+    const iterator = new UnionIterator([
+      range(0, 2),
+    ], { maxParallelIterators: 1 });
+    (await toArray(iterator)).sort().should.eql([0, 1, 2]);
+  });
+
+  it('should include all data from 2 non-empty sources - with maxParallelIterators: 1', async () => {
+    const iterator = new UnionIterator([
+      range(0, 2),
+      range(3, 4),
+    ], { maxParallelIterators: 1 });
+    (await toArray(iterator)).sort().should.eql([0, 1, 2, 3, 4]);
+  });
+
   it('should include all data from 1 non-empty and 4 empty sources - with maxParallelIterators: 1', async () => {
     const iterator = new UnionIterator([
       new EmptyIterator(),
@@ -77,6 +98,23 @@ describe('UnionIterator', () => {
       new EmptyIterator(),
     ], { maxParallelIterators: 1 });
     (await toArray(iterator)).sort().should.eql([0, 1, 2]);
+  });
+
+  it('should include all data from 4 empty sources - with maxParallelIterators: 1', async () => {
+    const iterator = new UnionIterator([
+      new EmptyIterator(),
+      new EmptyIterator(),
+      new EmptyIterator(),
+      new EmptyIterator(),
+    ], { maxParallelIterators: 1 });
+    (await toArray(iterator)).sort().should.eql([]);
+  });
+
+  it('should include all data from 1 empty source - with maxParallelIterators: 1', async () => {
+    const iterator = new UnionIterator([
+      new EmptyIterator(),
+    ], { maxParallelIterators: 1 });
+    (await toArray(iterator)).sort().should.eql([]);
   });
 
   describe('when constructed with an array of 0 sources', () => {


### PR DESCRIPTION
Supercedes #79 

The concerns about behavior (and reasons for a major version bump) that I pointed out there still remain. But not sure if I have a good solution for those at this point.

Before
For loop with 5x10^9 elems: 5.207s
UnionIterator 2x10^7 iterators: 30.297s
UnionIterator 1000x500 iterators: 1.897s
UnionIterator 1000x500 iterators - max parallelism of 1: 1.837s

After
For loop with 5x10^9 elems: 7.832s
UnionIterator 2x10^7 iterators: 3.844s
UnionIterator 1000x500 iterators: 276.211ms
UnionIterator 1000x500 iterators - max parallelism of 1: 157.52ms