### PR TITLE
Fix slow async sources not being destroyed

### DIFF
--- a/test/ClonedIterator-test.js
+++ b/test/ClonedIterator-test.js
@@ -84,10 +84,6 @@ describe('ClonedIterator', () => {
         clone.close();
       });
 
-      it('should not do anything when a source is set', () => {
-        clone.source = {};
-      });
-
       it('should have undefined as `source` property', () => {
         expect(clone.source).to.be.undefined;
       });
@@ -114,6 +110,13 @@ describe('ClonedIterator', () => {
 
       it('should return an empty property set', () => {
         clone.getProperties().should.deep.equal({});
+      });
+
+      it('should destroy a newly added source', () => {
+        const source = new AsyncIterator();
+        sinon.spy(source, 'destroy');
+        clone.source = source;
+        source.destroy.should.have.been.calledOnce;
       });
     });
   });


### PR DESCRIPTION
When a TransformIterator receives an async callback as input, but the callback is very slow, race conditions could occur when destroying the iterator.
Concretely, when the iterator was closed/destroy before the callback resolves, the underlying iterator would never be destroyed.

FYI, this caused major problems in the context with link traversal, where the query would end, but underlying link traversal iterators (which can be infinite) kept on running.

This fix should also be taken into account when #83 is being fixed.