### PR TITLE
Make iterators AsyncIterable, Closes #89

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -4,6 +4,10 @@
     node: true,
   },
 
+  globals: {
+    AsyncIterable: false,
+  },
+
   parser: "@typescript-eslint/parser",
 
   parserOptions: {

--- a/README.md
+++ b/README.md
@@ -174,6 +174,25 @@ numbers.setProperty('later', 'value');
 // 'value'
 ```
 
+### Consuming an AsyncIterator as EcmaScript-AsyncIterator
+Due to the syntactical sugar [EcmaScript's AsyncIterator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AsyncIterator)
+provides, our iterators can also be consumed as such.
+If high performance over large iterators is required, this method of consumption not recommended.
+
+```JavaScript
+const numbers = new IntegerIterator({ start: 1, end: 100 });
+
+for await (const number of numbers)
+  console.log('number', number);
+console.log('all done!');
+```
+
+Error events emitted within the iterator can be caught by wrapping the for-await-block in a try-catch.
+
+In cases where the returned EcmaScript AsyncIterator will not be fully consumed,
+it is recommended to manually listen for error events on the main AsyncIterator
+to avoid uncaught error messages.
+
 ## License
 The asynciterator library is copyrighted by [Ruben Verborgh](http://ruben.verborgh.org/)
 and released under the [MIT License](http://opensource.org/licenses/MIT).

--- a/asynciterator.ts
+++ b/asynciterator.ts
@@ -571,6 +571,11 @@ export class AsyncIterator<T> extends EventEmitter implements AsyncIterable<T> {
   /**
    * An AsyncIterator is async iterable.
    * This allows iterators to be used via the for-await syntax.
+   *
+   * In cases where the returned EcmaScript AsyncIterator will not be fully consumed,
+   * it is recommended to manually listen for error events on the main AsyncIterator
+   * to avoid uncaught error messages.
+   *
    * @returns {ESAsyncIterator<T>} An EcmaScript AsyncIterator
    */
   [Symbol.asyncIterator](): ESAsyncIterator<T> {
@@ -611,7 +616,7 @@ export class AsyncIterator<T> extends EventEmitter implements AsyncIterable<T> {
         currentResolve = currentReject = pendingError = null;
         removeListeners();
       }
-      else if (pendingError !== null) {
+      else if (pendingError === null) {
         pendingError = error;
       }
     }

--- a/asynciterator.ts
+++ b/asynciterator.ts
@@ -76,12 +76,11 @@ export const ENDED = 1 << 4;
 */
 export const DESTROYED = 1 << 5;
 
-
 /**
   An asynchronous iterator provides pull-based access to a stream of objects.
   @extends module:asynciterator.EventEmitter
 */
-export class AsyncIterator<T> extends EventEmitter {
+export class AsyncIterator<T> extends EventEmitter implements AsyncIterable<T> {
   protected _state: number;
   private _readable = false;
   protected _properties?: { [name: string]: any };
@@ -567,6 +566,47 @@ export class AsyncIterator<T> extends EventEmitter {
   */
   clone(): ClonedIterator<T> {
     return new ClonedIterator<T>(this);
+  }
+
+  /**
+   * An AsyncIterator is async iterable.
+   * This allows iterators to be used via the for-await syntax.
+   * @returns {ESAsyncIterator<T>} An EcmaScript AsyncIterator
+   */
+  [Symbol.asyncIterator](): ESAsyncIterator<T> {
+    const it = this;
+    // An EcmaScript AsyncIterator exposes the next() function that can be invoked repeatedly
+    return {
+      next(): Promise<IteratorResult<T>> {
+        return new Promise<IteratorResult<T>>((resolve, reject) => {
+          it.on('error', reject);
+          function tryResolve(): void {
+            const value = it.read();
+            if (value !== null) {
+              // Immediately resolve if we have read an element
+              it.removeListener('error', reject);
+              resolve({ done: false, value });
+            }
+            else if (it.done) {
+              // Close if we're done
+              it.removeListener('error', reject);
+              resolve({ done: true, value: undefined });
+            }
+            else {
+              // In all other cases, wait for the iterator to become readable or ended
+              const nextCallback = () => {
+                it.removeListener('readable', nextCallback);
+                it.removeListener('end', nextCallback);
+                tryResolve();
+              };
+              it.once('readable', nextCallback);
+              it.once('end', nextCallback);
+            }
+          }
+          tryResolve();
+        });
+      },
+    };
   }
 }
 
@@ -2243,6 +2283,13 @@ export interface TransformOptions<S, D> extends TransformIteratorOptions<S> {
 
 export interface MultiTransformOptions<S, D> extends TransformOptions<S, D> {
   multiTransform?: (item: S) => AsyncIterator<D>;
+}
+
+/**
+ * Copy of the EcmaScript AsyncIterator interface, which we can not use directly due to the name conflict.
+ */
+interface ESAsyncIterator<T> {
+  next(value?: any): Promise<IteratorResult<T>>;
 }
 
 type MaybePromise<T> =

--- a/test/integration-test.js
+++ b/test/integration-test.js
@@ -25,6 +25,23 @@ describe('Integration tests', () => {
     });
   });
 
+  describe('A sequence of ArrayIterator, TransformIterator, and Unioniterator is AsyncIterable', () => {
+    let arrayIterator, transformIterator, unionIterator;
+
+    before(() => {
+      arrayIterator = new ArrayIterator([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], { autoStart: false });
+      transformIterator = new TransformIterator(arrayIterator, { autoStart: false });
+      unionIterator = new UnionIterator([transformIterator], { autoStart: false });
+    });
+
+    it('returns all values', async () => {
+      const values = [];
+      for await (const value of unionIterator)
+        values.push(value);
+      values.should.eql([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+    });
+  });
+
   describe('Cloning iterators', () => {
     describe('A clone of an empty ArrayIterator without autoStart', () => {
       let arrayIterator, clonedIterator;


### PR DESCRIPTION
While this will likely come at the cost of lower performance compared to plain data-events, we should add this for use cases where code readability is preferred over performance.