### PR TITLE
Fix 3 tests where the wrong event is checked.

### DIFF
--- a/test/AsyncIterator-test.js
+++ b/test/AsyncIterator-test.js
@@ -647,7 +647,7 @@ describe('AsyncIterator', () => {
       });
 
       it('should not have listeners for the `data` event', () => {
-        EventEmitter.listenerCount(iterator, 'readable').should.equal(0);
+        EventEmitter.listenerCount(iterator, 'data').should.equal(0);
       });
 
       it('should not be listening for the `readable` event', () => {
@@ -683,7 +683,7 @@ describe('AsyncIterator', () => {
       });
 
       it('should not have listeners for the `data` event', () => {
-        EventEmitter.listenerCount(iterator, 'readable').should.equal(0);
+        EventEmitter.listenerCount(iterator, 'data').should.equal(0);
       });
 
       it('should not be listening for the `readable` event', () => {
@@ -725,7 +725,7 @@ describe('AsyncIterator', () => {
       });
 
       it('should not have listeners for the `data` event', () => {
-        EventEmitter.listenerCount(iterator, 'readable').should.equal(0);
+        EventEmitter.listenerCount(iterator, 'data').should.equal(0);
       });
 
       it('should not be listening for the `readable` event', () => {


### PR DESCRIPTION
I found 3 tests where the wrong event was checked. The title said 'should not have listeners for the `data` event' and in the test the 'readable' event was checked for listeners.