### PR TITLE
perf: uses setImmediate() implementation from tiny-set-immediate

### DIFF
--- a/asynciterator.ts
+++ b/asynciterator.ts
@@ -6,9 +6,10 @@
 import { EventEmitter } from 'events';
 import { LinkedList } from './linkedlist';
 import { createTaskScheduler } from './taskscheduler';
+import { setImmediate } from 'tiny-set-immediate';
 import type { Task, TaskScheduler } from './taskscheduler';
 
-let taskScheduler: TaskScheduler = createTaskScheduler();
+let taskScheduler: TaskScheduler = createTaskScheduler(setImmediate);
 
 // Export utilities for reuse
 export { LinkedList };

--- a/asynciterator.ts
+++ b/asynciterator.ts
@@ -6,10 +6,9 @@
 import { EventEmitter } from 'events';
 import { LinkedList } from './linkedlist';
 import { createTaskScheduler } from './taskscheduler';
-import { setImmediate } from 'tiny-set-immediate';
 import type { Task, TaskScheduler } from './taskscheduler';
 
-let taskScheduler: TaskScheduler = createTaskScheduler(setImmediate);
+let taskScheduler: TaskScheduler = createTaskScheduler();
 
 // Export utilities for reuse
 export { LinkedList };

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "asynciterator",
       "version": "3.9.0",
       "license": "MIT",
+      "dependencies": {
+        "tiny-set-immediate": "^1.0.2"
+      },
       "devDependencies": {
         "@babel/cli": "^7.10.1",
         "@babel/core": "^7.10.2",
@@ -3926,6 +3929,12 @@
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
     },
+    "node_modules/tiny-set-immediate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tiny-set-immediate/-/tiny-set-immediate-1.0.2.tgz",
+      "integrity": "sha512-EVbaM4zXFWS4CIqVoPzY7XIioQ5LU1p49AHizwPO1KyFyp/gxy5SA8mDmfDVl/2WLQiHgUL+esO6Ig+KhpUxUw==",
+      "license": "MIT"
+    },
     "node_modules/to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
@@ -7116,6 +7125,11 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
+    },
+    "tiny-set-immediate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tiny-set-immediate/-/tiny-set-immediate-1.0.2.tgz",
+      "integrity": "sha512-EVbaM4zXFWS4CIqVoPzY7XIioQ5LU1p49AHizwPO1KyFyp/gxy5SA8mDmfDVl/2WLQiHgUL+esO6Ig+KhpUxUw=="
     },
     "to-fast-properties": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -64,5 +64,8 @@
     "sinon": "^7.2.7",
     "sinon-chai": "^3.3.0",
     "typescript": "^3.9.5"
+  },
+  "dependencies": {
+    "tiny-set-immediate": "^1.0.2"
   }
 }

--- a/taskscheduler.ts
+++ b/taskscheduler.ts
@@ -1,14 +1,11 @@
+
 const resolved = Promise.resolve(undefined);
 
 // Returns a function that asynchronously schedules a task
-export function createTaskScheduler() : TaskScheduler {
+export function createTaskScheduler(scheduleMacrotask: TaskScheduler) : TaskScheduler {
   // Use or create a microtask scheduler
   const scheduleMicrotask = typeof queueMicrotask === 'function' ?
     queueMicrotask : (task: Task) => resolved.then(task);
-
-  // Use or create a macrotask scheduler
-  const scheduleMacrotask = typeof setImmediate === 'function' ?
-    setImmediate : (task: Task) => setTimeout(task, 0);
 
   // Interrupt with a macrotask every once in a while to avoid freezing
   let i = 0;

--- a/taskscheduler.ts
+++ b/taskscheduler.ts
@@ -1,4 +1,3 @@
-
 const resolved = Promise.resolve(undefined);
 
 // Returns a function that asynchronously schedules a task

--- a/taskscheduler.ts
+++ b/taskscheduler.ts
@@ -1,7 +1,9 @@
+import { setImmediate } from 'tiny-set-immediate';
+
 const resolved = Promise.resolve(undefined);
 
 // Returns a function that asynchronously schedules a task
-export function createTaskScheduler(scheduleMacrotask: TaskScheduler) : TaskScheduler {
+export function createTaskScheduler(scheduleMacrotask: TaskScheduler = setImmediate) : TaskScheduler {
   // Use or create a microtask scheduler
   const scheduleMicrotask = typeof queueMicrotask === 'function' ?
     queueMicrotask : (task: Task) => resolved.then(task);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -39,7 +39,7 @@
     "noFallthroughCasesInSwitch": true,       /* Report errors for fallthrough cases in switch statement. */
 
     /* Module Resolution Options */
-    // "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    "moduleResolution": "node",               /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
     // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
     // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */


### PR DESCRIPTION
This PR changes the task scheduler to use an externally-provided macrotask scheduling function and defaults to using the `setImmediate()` implementation from [`tiny-set-immediate`](https://github.com/jquense/tiny-set-immediate).

This is done to work around performance issues discovered in https://github.com/comunica/comunica/discussions/1552 and ultimately traced back to the enormous difference between `setImmediate()`, which is only available is Node.js-like environments, and `setTimeout(fn, 0)`, which is what the in-house `scheduleMacrotask` function would fallback to prior to this change. The former is roughly 90x faster than the latter.